### PR TITLE
feat: macOS signing/notarization, integration scaffolding docs, doc accuracy fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,76 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build macOS binaries
+        run: |
+          VERSION="${{ github.event.inputs.tag || github.ref_name }}"
+          LDFLAGS="-s -w -X main.version=${VERSION}"
+          mkdir -p dist
+          GOOS=darwin GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-darwin-arm64" .
+          GOOS=darwin GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-darwin-amd64" .
+
+      - name: Import signing certificate
+        env:
+          APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          echo "$APPLE_CERT_P12" | base64 --decode > certificate.p12
+          security create-keychain -p "" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import certificate.p12 -k build.keychain -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
+          rm certificate.p12
+
+      - name: Sign binaries
+        run: |
+          IDENTITY=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application" | awk -F '"' '{print $2}')
+          for arch in arm64 amd64; do
+            codesign --sign "$IDENTITY" --timestamp --options runtime "dist/snipemgr-darwin-${arch}"
+          done
+
+      - name: Notarize binaries
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          echo "$APPLE_API_KEY" | base64 --decode > api_key.p8
+          for arch in arm64 amd64; do
+            ditto -c -k --keepParent "dist/snipemgr-darwin-${arch}" "dist/snipemgr-darwin-${arch}.zip"
+            xcrun notarytool submit "dist/snipemgr-darwin-${arch}.zip" \
+              --key api_key.p8 \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer-id "$APPLE_API_ISSUER_ID" \
+              --wait
+            rm "dist/snipemgr-darwin-${arch}.zip"
+          done
+
+      - name: Clean up
+        if: always()
+        run: |
+          rm -f api_key.p8
+          security delete-keychain build.keychain
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-binaries
+          path: dist/
+
+  build-other:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,17 +95,41 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build binaries
+      - name: Build Linux and Windows binaries
         run: |
           VERSION="${{ github.event.inputs.tag || github.ref_name }}"
           LDFLAGS="-s -w -X main.version=${VERSION}"
           mkdir -p dist
-          GOOS=darwin  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-darwin-arm64"       .
-          GOOS=darwin  GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-darwin-amd64"       .
-          GOOS=linux   GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-linux-amd64"        .
-          GOOS=linux   GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-linux-arm64"        .
-          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-windows-amd64.exe"  .
-          cd dist && sha256sum * > checksums.txt
+          GOOS=linux   GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-linux-amd64"       .
+          GOOS=linux   GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-linux-arm64"       .
+          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-windows-amd64.exe" .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: other-binaries
+          path: dist/
+
+  release:
+    needs: [build-macos, build-other]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: macos-binaries
+          path: dist/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: other-binaries
+          path: dist/
+
+      - name: Generate checksums
+        run: cd dist && sha256sum * > checksums.txt
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,7 +56,7 @@ repos. Load and follow it with these caveats:
 
 ## Key decisions already made
 
-- **Language:** Go 1.22+, same stack as the integrations (cobra + viper + slog)
+- **Language:** Go 1.25+, same stack as the integrations (cobra + viper + slog)
 - **Discovery mechanism:** GitHub Search API (`topic:2snipe+user:{owner}`) then
   GitHub Contents API (`/repos/{owner}/{repo}/contents/2snipe.json`) to fetch and
   validate each manifest. Repos without a valid `2snipe.json` are silently excluded.
@@ -152,7 +152,7 @@ internal/
   workflows/
     release.yml     # cross-platform release build on v* tags
     ci.yml          # go vet + go test on every push/PR to main
-go.mod              # module: github.com/jackvaughanjr/2snipe-manager, go 1.23
+go.mod              # module: github.com/jackvaughanjr/2snipe-manager, go 1.25
 go.sum
 snipemgr.example.yaml   # manager's own config (GCP project, registry sources, etc.)
 README.md

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ curl -L https://github.com/jackvaughanjr/2snipe-manager/releases/latest/download
 curl -L https://github.com/jackvaughanjr/2snipe-manager/releases/latest/download/snipemgr-linux-arm64 -o snipemgr && chmod +x snipemgr
 ```
 
-Move the binary somewhere on your `$PATH` (e.g. `/usr/local/bin/snipemgr`).
+**Install to your `$PATH`:**
+
+```bash
+sudo install -m 755 snipemgr /usr/local/bin/snipemgr
+```
 
 **2. Run the setup wizard:**
 
@@ -77,7 +81,7 @@ snipemgr status
 - The [`gcloud` CLI](https://cloud.google.com/sdk/docs/install) installed and authenticated
 - See [GCP setup](#gcp-setup-required-for---secrets-backend-gcp) below
 
-**To build from source** — Go 1.22+
+**To build from source** — Go 1.25+
 
 **GitHub token (optional)** — without one, GitHub rate-limits API calls to 60/hr. Sufficient for occasional use but tight if you run `snipemgr list` frequently. Set `registry.github_token` in `snipemgr.yaml` with a token scoped to `public_repo` (or `repo` for private integration repos).
 
@@ -209,7 +213,7 @@ cd github2snipe
 If the repo doesn't have a `Dockerfile`, create a minimal one:
 
 ```dockerfile
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /src
 COPY . .
 RUN go build -o /app/github2snipe .
@@ -300,7 +304,7 @@ Also add the GitHub topic `2snipe` to the repo (Settings → Topics) — this is
 
 ## Tech stack
 
-- **Language:** Go 1.22+
+- **Language:** Go 1.25+
 - **CLI:** `cobra` + `viper` (same as all `*2snipe` integrations)
 - **Logging:** `log/slog`
 - **Interactive forms:** `charmbracelet/huh`
@@ -320,6 +324,10 @@ docs/
   manifest-spec.md          Full spec for the 2snipe.json integration manifest file
   gcp-infra.md              GCP setup, IAM requirements, API references, cost estimate
   features-backlog.md       Post-core enhancement ideas, tiered by value and complexity
+  release.md                Versioning convention, release workflow template, and badge/install patterns for integrations
+  scaffolding.md            File structure, go.mod, cmd/, and syncer templates for new integrations
+  source-files.md           Verbatim snipeit and slack client source to copy into new integrations
+  snipeit-api.md            Snipe-IT API reference: envelope behavior, checkout/checkin, sync flow, gotchas
 ```
 
 Source code lives under `cmd/` and `internal/`.
@@ -328,12 +336,20 @@ Source code lives under `cmd/` and `internal/`.
 
 ## Contributing
 
-Read these before writing any code, in this order:
+**Working on `snipemgr` itself:** read these in order:
 
 1. `CONTEXT.md` — what this repo is, key decisions already made, and a reference table for the docs below
 2. `docs/architecture.md` — full component design
 3. `docs/order-of-operations.md` — build history, phase gotchas, and verification logs
 4. The relevant `docs/` file for the area you're working in
+
+**Building a new `*2snipe` integration:** read these in order:
+
+1. `docs/scaffolding.md` — standard file structure, go.mod, cmd/, and syncer templates
+2. `docs/source-files.md` — verbatim `snipeit` and `slack` client source to copy in
+3. `docs/snipeit-api.md` — Snipe-IT API reference, sync flow, and gotchas
+4. `docs/release.md` — versioning convention, release workflow, and README patterns
+5. `docs/manifest-spec.md` — the `2snipe.json` manifest your integration needs to be discoverable by `snipemgr`
 
 ---
 

--- a/docs/order-of-operations.md
+++ b/docs/order-of-operations.md
@@ -90,9 +90,10 @@ and config loading. No GCP or GitHub calls yet.
 
 ### Gotchas / deviations from plan
 
-**1. Go version bumped to 1.23 (planned: 1.22)**
+**1. Go version bumped to 1.23, then 1.25 (planned: 1.22)**
 `viper v1.21.0` requires `go 1.23.0`. `go get` automatically updated `go.mod` from
-`1.22` to `1.23.0`. All code is fully compatible; the version in `go.mod` is the
+`1.22` to `1.23.0`. Subsequently bumped to `1.25.0` when GCP client library
+dependencies required it. All code is fully compatible; the version in `go.mod` is the
 minimum required, not a constraint on the build machine.
 
 **2. Root command needs a `Run` field to display flags in `--help`**
@@ -341,7 +342,7 @@ and named test breakdown.
 
 ## Post-Phase 4 — v1.1.0 additions (2026-04-17)
 
-These features were added after Phase 4 completed, before the v1.0.0 tag was pushed.
+These features were added after Phase 4 completed, before the v1.1.0 tag was pushed.
 
 ### `snipemgr init` — first-time setup wizard
 
@@ -371,7 +372,7 @@ These features were added after Phase 4 completed, before the v1.0.0 tag was pus
 ### Release infrastructure
 
 - [x] `.github/release.yml` — PR-label categorization for auto-generated release notes
-- [x] README `## Version History` table updated to include all v1.0.0 additions
+- [x] README `## Version History` table updated to include all v1.1.0 additions
 
 ---
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,167 @@
+# Releases and versioning
+
+> **Note:** This document covers releases for `*2snipe` **integration** repos
+> (e.g. `github2snipe`, `okta2snipe`). The `snipemgr` release workflow is more
+> involved — it includes macOS code signing and notarization. See
+> `.github/workflows/release.yml` in this repo for that workflow.
+
+---
+
+## How releases work
+
+Releases are created by GitHub Actions on a `v*` tag push. The workflow:
+1. Builds four platform binaries with the version embedded via ldflags.
+2. Creates a GitHub release with auto-generated notes from commits.
+3. Attaches all four binaries as release assets.
+
+To cut a new release:
+```bash
+git tag v1.2.3
+git push origin v1.2.3
+```
+
+The workflow can also be triggered manually from the Actions tab (useful for
+re-releasing a tag or testing the workflow).
+
+---
+
+## Versioning convention
+
+All `*2snipe` integrations use [semver](https://semver.org) with the following rules:
+
+- **First production commit = v1.0.0.** All integrations are deployed and used before
+  a v1.0.0 tag, so the first working commit counts as v1.0.0 regardless of maturity.
+- **Increment minor** (`v1.X.0`) for new features: new flags, new commands, new config
+  keys that change sync behaviour, new auto-create patterns.
+- **Increment patch** (`v1.0.X`) for bug fixes, dependency updates, and documentation
+  changes.
+- **Never auto-shrink** patch numbers for doc-only commits — each commit to `main`
+  that ships should increment either minor or patch.
+
+Every integration README must include a `## Version History` table. Format:
+
+```markdown
+## Version History
+
+| Version | Key changes |
+|---------|-------------|
+| v1.2.0 | Added `--create-users` flag to automatically provision missing Snipe-IT accounts |
+| v1.1.0 | ... |
+| v1.0.0 | Initial release — ... |
+```
+
+List versions newest-first. Keep each row to one sentence or a short comma-separated
+list of the key changes. Update this table in the same commit as the version tag.
+
+---
+
+## Release workflow — .github/workflows/release.yml
+
+Replace `<repo>` with your binary name:
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.0.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build binaries
+        run: |
+          VERSION="${{ github.event.inputs.tag || github.ref_name }}"
+          LDFLAGS="-s -w -X main.version=${VERSION}"
+          mkdir -p dist
+          GOOS=darwin  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o "dist/<repo>-darwin-arm64"       .
+          GOOS=linux   GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/<repo>-linux-amd64"        .
+          GOOS=linux   GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o "dist/<repo>-linux-arm64"        .
+          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/<repo>-windows-amd64.exe"  .
+          cd dist && sha256sum * > checksums.txt
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          files: dist/*
+```
+
+Key points:
+- `permissions: contents: write` is required for the release step.
+- `-s -w` strips debug info and symbol tables — reduces binary size significantly.
+- `-X main.version=${VERSION}` embeds the tag name into the binary.
+- `generate_release_notes: true` uses GitHub's automatic release notes from commits.
+- `workflow_dispatch` with a tag input allows manual re-releases.
+- Integration binaries run as Docker containers in Cloud Run — macOS signing is
+  not needed. The simple Ubuntu workflow above is sufficient.
+
+---
+
+## README badge row
+
+Every integration README must include a badge row immediately after the `# Title` heading.
+Replace `<owner>` and `<repo>` with the actual values:
+
+```markdown
+[![Latest Release](https://img.shields.io/github/v/release/<owner>/<repo>)](https://github.com/<owner>/<repo>/releases/latest) [![Go Version](https://img.shields.io/github/go-mod/go-version/<owner>/<repo>)](go.mod) [![License](https://img.shields.io/github/license/<owner>/<repo>)](LICENSE) [![Build](https://github.com/<owner>/<repo>/actions/workflows/release.yml/badge.svg)](https://github.com/<owner>/<repo>/actions/workflows/release.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/<owner>/<repo>)](https://goreportcard.com/report/github.com/<owner>/<repo>) [![Downloads](https://img.shields.io/github/downloads/<owner>/<repo>/total)](https://github.com/<owner>/<repo>/releases)
+```
+
+Badges included:
+- **Latest Release** — current version tag from GitHub releases
+- **Go Version** — pulled automatically from `go.mod`
+- **License** — pulled from the repo's license file
+- **Build** — status of the `release.yml` workflow
+- **Go Report Card** — static analysis score (requires a one-time visit to goreportcard.com to trigger the first scan)
+- **Downloads** — total binary downloads across all releases
+
+---
+
+## README installation section
+
+Every integration README must include an Installation section with curl commands.
+Pattern (replace `<repo>` and `<owner>`):
+
+```markdown
+## Installation
+
+**Download a pre-built binary** from the [latest release](https://github.com/<owner>/<repo>/releases/latest):
+
+    # macOS (Apple Silicon)
+    curl -L https://github.com/<owner>/<repo>/releases/latest/download/<repo>-darwin-arm64 -o <repo>
+    chmod +x <repo>
+
+    # Linux (amd64)
+    curl -L https://github.com/<owner>/<repo>/releases/latest/download/<repo>-linux-amd64 -o <repo>
+    chmod +x <repo>
+
+    # Linux (arm64)
+    curl -L https://github.com/<owner>/<repo>/releases/latest/download/<repo>-linux-arm64 -o <repo>
+    chmod +x <repo>
+
+Or build from source:
+
+    git clone https://github.com/<owner>/<repo>
+    cd <repo>
+    go build -o <repo> .
+```

--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -1,0 +1,788 @@
+# Scaffolding templates
+
+These files contain vendor-specific placeholders marked with `TODO` or angle-bracket
+tokens (`<vendor>`, `<repo>`, `<module>`, `<Vendor>`). Replace them before building.
+
+---
+
+## go.mod
+
+```
+module github.com/<owner>/<repo>
+
+go 1.25
+
+require (
+    github.com/spf13/cobra v1.10.2
+    github.com/spf13/viper v1.21.0
+    golang.org/x/time v0.5.0
+)
+```
+
+Run `go mod tidy` after creating this file to populate `go.sum` and pin indirect
+dependencies. Never create `go.sum` manually.
+
+---
+
+## .gitignore
+
+```
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+go.work
+go.work.sum
+.env
+settings.yaml
+*.json
+.cache/
+<repo>
+.DS_Store
+```
+
+---
+
+## settings.example.yaml
+
+```yaml
+# <repo> configuration
+# Copy this file to settings.yaml and fill in your values.
+# settings.yaml is gitignored and should never be committed.
+#
+# All values can be overridden with environment variables.
+# See CONTEXT.md for the full list of env var overrides.
+
+<vendor>:
+  # Base URL of the source system API.
+  url: "https://your-instance.example.com"
+
+  # API credential for the source system.
+  api_token: ""
+
+snipe_it:
+  # Base URL of your Snipe-IT instance.
+  url: "https://your-snipe-it-instance.example.com"
+
+  # Snipe-IT API key with license management permissions.
+  # Generate one at: Admin → API Keys
+  api_key: ""
+
+  # Name of the license to assign seats to.
+  # Created automatically on first run if it does not exist.
+  license_name: "<Vendor Product Name>"
+
+  # Snipe-IT category ID to assign to the license when created. Required.
+  # Find IDs at: Admin → Categories, or via the Snipe-IT API.
+  license_category_id: 0
+
+  # Optional: total purchased seat count for the license.
+  # Use when the vendor API does not expose purchased seat count. If 0 and the
+  # vendor API also returns nothing, active member count is used as the floor.
+  # Seats are never shrunk automatically.
+  license_seats: 0
+
+  # Optional: manufacturer ID. If 0, auto find/create from vendor name.
+  license_manufacturer_id: 0
+
+  # Optional: supplier ID. If 0, no supplier is set on the license.
+  license_supplier_id: 0
+
+sync:
+  # Simulate a full sync without making any changes.
+  # Overridden by the --dry-run flag.
+  dry_run: false
+
+  # Re-sync seat notes even if they appear up to date.
+  # Overridden by the --force flag.
+  force: false
+
+  # Snipe-IT API rate limit in milliseconds between requests.
+  # 500ms = 2 req/s. Increase if you encounter 429 errors.
+  rate_limit_ms: 500
+
+slack:
+  # Incoming webhook URL for Slack notifications.
+  # Optional. If omitted, all notifications are silently skipped.
+  # Can be overridden with the SLACK_WEBHOOK environment variable.
+  webhook_url: ""
+```
+
+---
+
+## main.go
+
+```go
+package main
+
+import "github.com/<owner>/<repo>/cmd"
+
+// version is set at build time via -ldflags "-X main.version=vX.Y.Z"
+var version = "dev"
+
+func main() {
+	cmd.SetVersion(version)
+	cmd.Execute()
+}
+```
+
+---
+
+## cmd/root.go
+
+```go
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+var rootCmd = &cobra.Command{
+	Use:   "<repo>",
+	Short: "Sync active <Vendor> users into Snipe-IT as license seat assignments",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// Suppress cobra's duplicate "Error: ..." echo for runtime errors.
+		// SilenceUsage is NOT set here — cobra validates Args after PersistentPreRunE,
+		// so setting it here would also silence the usage block on missing-arg errors.
+		// Set SilenceUsage inside each RunE via the silentUsage wrapper instead.
+		cmd.Root().SilenceErrors = true
+		initLogging()
+		return nil
+	},
+}
+
+// SetVersion injects the build-time version string into the root command.
+func SetVersion(v string) {
+	rootCmd.Version = v
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+// silentUsage wraps a RunE function so that SilenceUsage is set before the
+// function body runs. Because cobra validates Args before calling RunE, arg/flag
+// errors still print the usage block; only errors returned from RunE itself
+// are silenced.
+func silentUsage(fn func(*cobra.Command, []string) error) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		cmd.Root().SilenceUsage = true
+		return fn(cmd, args)
+	}
+}
+
+// fatal prints an error to stderr and returns it. Use in RunE instead of bare
+// return fmt.Errorf(...) so errors are visible when SilenceErrors is set.
+func fatal(format string, a ...any) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	return err
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "settings.yaml", "path to config file")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "INFO-level logging")
+	rootCmd.PersistentFlags().BoolP("debug", "d", false, "DEBUG-level logging")
+	rootCmd.PersistentFlags().String("log-file", "", "append logs to this file")
+	rootCmd.PersistentFlags().String("log-format", "text", "log format: text or json")
+
+	_ = viper.BindPFlag("log.verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	_ = viper.BindPFlag("log.debug", rootCmd.PersistentFlags().Lookup("debug"))
+	_ = viper.BindPFlag("log.file", rootCmd.PersistentFlags().Lookup("log-file"))
+	_ = viper.BindPFlag("log.format", rootCmd.PersistentFlags().Lookup("log-format"))
+}
+
+func initConfig() {
+	viper.SetConfigFile(cfgFile)
+	viper.SetConfigType("yaml")
+
+	// TODO: add vendor-specific env var bindings here.
+	// Standard bindings (keep these for all integrations):
+	viper.BindEnv("<vendor>.url", "<VENDOR>_URL")         // TODO: replace tokens
+	viper.BindEnv("<vendor>.api_token", "<VENDOR>_TOKEN") // TODO: replace tokens
+	viper.BindEnv("snipe_it.url", "SNIPE_URL")
+	viper.BindEnv("snipe_it.api_key", "SNIPE_TOKEN")
+	viper.BindEnv("slack.webhook_url", "SLACK_WEBHOOK")
+	_ = viper.BindEnv("sync.rate_limit_ms", "SNIPE_RATE_LIMIT_MS")
+
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			slog.Warn("could not read config file", "error", err)
+		}
+	}
+}
+
+func initLogging() {
+	level := slog.LevelWarn
+	if viper.GetBool("log.debug") {
+		level = slog.LevelDebug
+	} else if viper.GetBool("log.verbose") {
+		level = slog.LevelInfo
+	}
+
+	var w io.Writer = os.Stderr
+	if path := viper.GetString("log.file"); path != "" {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			slog.Warn("could not open log file", "path", path, "error", err)
+		} else {
+			w = io.MultiWriter(os.Stderr, f)
+		}
+	}
+
+	opts := &slog.HandlerOptions{Level: level}
+	var handler slog.Handler
+	if viper.GetString("log.format") == "json" {
+		handler = slog.NewJSONHandler(w, opts)
+	} else {
+		handler = slog.NewTextHandler(w, opts)
+	}
+	slog.SetDefault(slog.New(handler))
+}
+```
+
+---
+
+## cmd/sync.go
+
+```go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	// TODO: replace with your vendor package import path
+	vendor "<module>/internal/<vendor>"
+	"<module>/internal/slack"
+	"<module>/internal/snipeit"
+	"<module>/internal/sync"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Sync active <Vendor> users into Snipe-IT license seats",
+	RunE:  silentUsage(runSync),
+}
+
+func init() {
+	rootCmd.AddCommand(syncCmd)
+
+	syncCmd.Flags().Bool("dry-run", false, "simulate without making changes")
+	syncCmd.Flags().Bool("force", false, "re-sync even if notes appear up to date")
+	syncCmd.Flags().String("email", "", "sync a single user by email address")
+	syncCmd.Flags().Bool("create-users", false, "create Snipe-IT accounts for unmatched users")
+	syncCmd.Flags().Bool("no-slack", false, "suppress Slack notifications for this run")
+
+	_ = viper.BindPFlag("sync.dry_run", syncCmd.Flags().Lookup("dry-run"))
+	_ = viper.BindPFlag("sync.force", syncCmd.Flags().Lookup("force"))
+	_ = viper.BindPFlag("sync.create_users", syncCmd.Flags().Lookup("create-users"))
+}
+
+func runSync(cmd *cobra.Command, args []string) error {
+	// TODO: replace with your vendor client constructor and config keys
+	vendorClient := vendor.NewClient(
+		viper.GetString("<vendor>.url"),
+		viper.GetString("<vendor>.api_token"),
+	)
+	rateLimitMs := viper.GetInt("sync.rate_limit_ms")
+	if rateLimitMs <= 0 {
+		rateLimitMs = 500
+	}
+	snipeClient := snipeit.NewClient(
+		viper.GetString("snipe_it.url"),
+		viper.GetString("snipe_it.api_key"),
+		rateLimitMs,
+	)
+
+	emailFilter, _ := cmd.Flags().GetString("email")
+	noSlack, _ := cmd.Flags().GetBool("no-slack")
+
+	categoryID := viper.GetInt("snipe_it.license_category_id")
+	if categoryID == 0 {
+		return fatal("snipe_it.license_category_id is required in settings.yaml")
+	}
+
+	cfg := sync.Config{
+		DryRun:            viper.GetBool("sync.dry_run"),
+		Force:             viper.GetBool("sync.force"),
+		CreateUsers:       viper.GetBool("sync.create_users"),
+		LicenseName:       viper.GetString("snipe_it.license_name"),
+		LicenseCategoryID: categoryID,
+		ManufacturerID:    viper.GetInt("snipe_it.license_manufacturer_id"),
+		SupplierID:        viper.GetInt("snipe_it.license_supplier_id"),
+	}
+
+	if cfg.LicenseName == "" {
+		cfg.LicenseName = "<Vendor Product Name>" // TODO: replace with default license name
+	}
+
+	if cfg.DryRun {
+		slog.Info("dry-run mode enabled — no changes will be made")
+	}
+
+	slackClient := slack.NewClient(viper.GetString("slack.webhook_url"))
+	ctx := context.Background()
+
+	syncer := sync.NewSyncer(vendorClient, snipeClient, cfg)
+	result, err := syncer.Run(ctx, emailFilter)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "sync failed: %v\n", err)
+		if !cfg.DryRun && !noSlack {
+			msg := fmt.Sprintf("<repo> sync failed: %v", err) // TODO: replace <repo>
+			if notifyErr := slackClient.Send(ctx, msg); notifyErr != nil {
+				slog.Warn("slack notification failed", "error", notifyErr)
+			}
+		}
+		return err
+	}
+
+	if !cfg.DryRun && !noSlack {
+		for _, email := range result.UnmatchedEmails {
+			// TODO: replace <repo> and <Vendor> in message
+			msg := fmt.Sprintf("<repo>: no Snipe-IT account found for <Vendor> user — %s", email)
+			if notifyErr := slackClient.Send(ctx, msg); notifyErr != nil {
+				slog.Warn("slack notification failed", "email", email, "error", notifyErr)
+			}
+		}
+
+		// TODO: replace <repo> in message
+		msg := fmt.Sprintf(
+			"<repo> sync complete — checked out: %d, notes updated: %d, checked in: %d, skipped: %d, users created: %d, warnings: %d",
+			result.CheckedOut, result.NotesUpdated, result.CheckedIn, result.Skipped, result.UsersCreated, result.Warnings,
+		)
+		if notifyErr := slackClient.Send(ctx, msg); notifyErr != nil {
+			slog.Warn("slack notification failed", "error", notifyErr)
+		}
+	}
+
+	fmt.Printf("Sync complete: checked_out=%d notes_updated=%d checked_in=%d skipped=%d users_created=%d warnings=%d\n",
+		result.CheckedOut, result.NotesUpdated, result.CheckedIn, result.Skipped, result.UsersCreated, result.Warnings)
+	return nil
+}
+```
+
+---
+
+## cmd/test.go
+
+```go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+
+	// TODO: replace with your vendor package import path
+	vendor "<module>/internal/<vendor>"
+	"<module>/internal/snipeit"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Validate API connections and report current state",
+	RunE:  silentUsage(runTest),
+}
+
+func init() {
+	rootCmd.AddCommand(testCmd)
+}
+
+func runTest(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	// TODO: replace with your vendor client constructor and config keys
+	vendorClient := vendor.NewClient(
+		viper.GetString("<vendor>.url"),
+		viper.GetString("<vendor>.api_token"),
+	)
+	rateLimitMs := viper.GetInt("sync.rate_limit_ms")
+	if rateLimitMs <= 0 {
+		rateLimitMs = 500
+	}
+	snipeClient := snipeit.NewClient(
+		viper.GetString("snipe_it.url"),
+		viper.GetString("snipe_it.api_key"),
+		rateLimitMs,
+	)
+
+	// --- Vendor ---
+	fmt.Println("=== <Vendor> ===") // TODO: replace <Vendor>
+	slog.Info("fetching active users", "url", viper.GetString("<vendor>.url"))
+	users, err := vendorClient.ListActiveUsers(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "<Vendor> error: %v\n", err) // TODO: replace <Vendor>
+		return err
+	}
+	fmt.Printf("Active users: %d\n", len(users))
+
+	// TODO: add vendor-specific output (role counts, group counts, etc.)
+
+	// --- Snipe-IT ---
+	fmt.Println("\n=== Snipe-IT ===")
+	licenseName := viper.GetString("snipe_it.license_name")
+	if licenseName == "" {
+		licenseName = "<Vendor Product Name>" // TODO: replace with default
+	}
+
+	slog.Info("looking up license in Snipe-IT", "url", viper.GetString("snipe_it.url"), "license", licenseName)
+	lic, err := snipeClient.FindLicenseByName(ctx, licenseName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Snipe-IT error: %v\n", err)
+		return err
+	}
+	if lic == nil {
+		fmt.Printf("License %q: not found\n", licenseName)
+	} else {
+		slog.Debug("license detail", "id", lic.ID, "seats", lic.Seats, "free", lic.FreeSeatsCount)
+		fmt.Printf("License %q: id=%d seats=%d free=%d\n",
+			lic.Name, lic.ID, lic.Seats, lic.FreeSeatsCount)
+	}
+
+	return nil
+}
+```
+
+---
+
+## internal/sync/syncer.go
+
+The syncer is the only file with significant vendor-specific logic. The overall
+structure is fixed; vendor-specific sections are marked with `TODO`.
+
+The `Config` struct, `Syncer` struct, and `NewSyncer` constructor are fully generic.
+The only vendor-specific parts are:
+- The import and type of the vendor client field
+- Step 4 (per-user metadata fetch)
+- Step 5 (manufacturer resolution — may not apply to all vendors)
+- `emailKey(user)` — must match your vendor user struct's email field
+- `buildNotes(metadata)` — formats vendor metadata into the seat notes string
+
+```go
+package sync
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	// TODO: replace with your vendor package import path
+	vendor "<module>/internal/<vendor>"
+	"<module>/internal/snipeit"
+)
+
+// Config controls sync behaviour.
+type Config struct {
+	DryRun      bool
+	Force       bool
+	CreateUsers bool
+	LicenseName       string
+	LicenseCategoryID int
+	// LicenseSeats is the total purchased seat count. Resolution priority:
+	// vendor API (if available) → this field → active member count (floor).
+	// If 0 and vendor API returns nothing, active member count is used.
+	LicenseSeats int
+	// ManufacturerID is optional. If 0, auto find/create from vendor name.
+	ManufacturerID int
+	// SupplierID is optional. If 0, no supplier is set on the license.
+	SupplierID int
+}
+
+// Syncer orchestrates the source → Snipe-IT license sync.
+type Syncer struct {
+	vendor *vendor.Client // TODO: replace with your vendor client type
+	snipe  *snipeit.Client
+	config Config
+}
+
+func NewSyncer(v *vendor.Client, snipe *snipeit.Client, cfg Config) *Syncer { // TODO: update type
+	return &Syncer{vendor: v, snipe: snipe, config: cfg}
+}
+
+// Run executes the full sync. emailFilter restricts the checkout pass to one
+// user (and skips the checkin pass entirely).
+func (s *Syncer) Run(ctx context.Context, emailFilter string) (Result, error) {
+	var result Result
+
+	// 1. Fetch active users from the source system (paginated).
+	slog.Info("fetching active users")
+	activeUsers, err := s.vendor.ListActiveUsers(ctx)
+	if err != nil {
+		return result, err
+	}
+	slog.Info("fetched active users", "count", len(activeUsers))
+
+	// 2. Build active email set (used in the checkin pass).
+	activeEmails := make(map[string]struct{}, len(activeUsers))
+	for _, u := range activeUsers {
+		activeEmails[emailKey(u)] = struct{}{}
+	}
+
+	// 3. Apply --email filter.
+	if emailFilter != "" {
+		needle := strings.ToLower(emailFilter)
+		filtered := activeUsers[:0]
+		for _, u := range activeUsers {
+			if emailKey(u) == needle {
+				filtered = append(filtered, u)
+				break
+			}
+		}
+		activeUsers = filtered
+		slog.Info("filtered to single user", "email", emailFilter, "found", len(activeUsers) > 0)
+	}
+
+	// 4. TODO: Fetch per-user metadata (roles, groups, licenses, etc.).
+	// Example pattern:
+	//   type userWithMeta struct {
+	//       user  vendor.User
+	//       meta  []vendor.Role  // or whatever your vendor provides
+	//   }
+	//   usersWithMeta := make([]userWithMeta, 0, len(activeUsers))
+	//   for _, u := range activeUsers {
+	//       meta, err := s.vendor.GetUserRoles(ctx, u.ID)
+	//       if err != nil {
+	//           slog.Warn("could not fetch metadata", "user", emailKey(u), "error", err)
+	//       }
+	//       usersWithMeta = append(usersWithMeta, userWithMeta{u, meta})
+	//   }
+
+	// 5. TODO: Resolve any Snipe-IT entities needed before license creation.
+	// Common pattern — find or create the manufacturer:
+	//   manufacturerID := s.config.ManufacturerID
+	//   if !s.config.DryRun && manufacturerID == 0 {
+	//       mfr, err := s.snipe.FindOrCreateManufacturer(ctx, "<Vendor>", "https://vendor.example.com")
+	//       if err != nil { return result, err }
+	//       manufacturerID = mfr.ID
+	//   }
+	manufacturerID := s.config.ManufacturerID
+
+	// 6. Resolve target seat count.
+	// Priority: vendor API (if available) → config override → active member count (floor).
+	// TODO: replace 0 with a vendor API call if the vendor exposes purchased seat count.
+	activeCount := len(activeEmails)
+	vendorLicenseSeats := 0 // TODO: fetch from vendor API if available
+	targetSeats := vendorLicenseSeats
+	if targetSeats == 0 {
+		targetSeats = s.config.LicenseSeats
+	}
+	if targetSeats == 0 {
+		targetSeats = activeCount
+	} else if targetSeats < activeCount {
+		slog.Warn("license seat count is less than active member count; using active count",
+			"license_seats", targetSeats, "active", activeCount)
+		targetSeats = activeCount
+	}
+
+	// Find or create the license.
+	// Dry-run: find only; synthesize placeholder if not found (id=0).
+	slog.Info("finding or creating license", "name", s.config.LicenseName)
+	var lic *snipeit.License
+	if s.config.DryRun {
+		lic, err = s.snipe.FindLicenseByName(ctx, s.config.LicenseName)
+		if err != nil {
+			return result, err
+		}
+		if lic == nil {
+			slog.Info("[dry-run] license not found; would be created", "name", s.config.LicenseName, "seats", targetSeats)
+			lic = &snipeit.License{Name: s.config.LicenseName, Seats: targetSeats}
+		}
+	} else {
+		lic, err = s.snipe.FindOrCreateLicense(ctx, s.config.LicenseName, targetSeats, s.config.LicenseCategoryID, manufacturerID, s.config.SupplierID)
+		if err != nil {
+			return result, err
+		}
+	}
+	slog.Info("license resolved", "id", lic.ID, "seats", lic.Seats, "free", lic.FreeSeatsCount)
+
+	// 7. Expand seats if needed (never shrink automatically).
+	if targetSeats > lic.Seats {
+		slog.Info("expanding license seats", "current", lic.Seats, "needed", targetSeats)
+		if !s.config.DryRun {
+			lic, err = s.snipe.UpdateLicenseSeats(ctx, lic.ID, targetSeats)
+			if err != nil {
+				return result, err
+			}
+		}
+	}
+
+	// 7.5. Refresh the license so FreeSeatsCount is accurate before ghost detection.
+	// Snipe-IT's POST (create) response returns free_seats_count: 0 regardless of
+	// seat count; a fresh GET gives the real value. Without this, ghost cleanup
+	// computes ghostCount = seats - 0 = N and drains all free seats before checkout.
+	if !s.config.DryRun && lic.ID != 0 {
+		lic, err = s.snipe.FindLicenseByID(ctx, lic.ID)
+		if err != nil {
+			return result, fmt.Errorf("refreshing license: %w", err)
+		}
+		slog.Debug("license refreshed", "id", lic.ID, "seats", lic.Seats, "free", lic.FreeSeatsCount)
+	}
+
+	// 8. Load current seat assignments.
+	// Dry-run with a synthetic license (id=0) skips the API call.
+	// In production, id=0 means something went wrong — fail fast.
+	checkedOutByEmail := make(map[string]*snipeit.LicenseSeat)
+	var freeSeats []*snipeit.LicenseSeat
+	if lic.ID != 0 {
+		slog.Info("loading current seat assignments")
+		seats, err := s.snipe.ListLicenseSeats(ctx, lic.ID)
+		if err != nil {
+			return result, err
+		}
+		for i := range seats {
+			seat := &seats[i]
+			if seat.AssignedTo != nil && seat.AssignedTo.Email != "" {
+				checkedOutByEmail[strings.ToLower(seat.AssignedTo.Email)] = seat
+			} else {
+				freeSeats = append(freeSeats, seat)
+			}
+		}
+	} else if !s.config.DryRun {
+		return result, fmt.Errorf("license resolved with id=0 in production mode — check Snipe-IT API permissions and required fields")
+	} else {
+		slog.Info("[dry-run] skipping seat load for new license")
+	}
+	slog.Info("seat state loaded", "checked_out", len(checkedOutByEmail), "free", len(freeSeats))
+
+	// 9. Checkout / update loop.
+	// TODO: replace `activeUsers` with `usersWithMeta` once step 4 is implemented,
+	// and update the notes call to pass the per-user metadata.
+	for _, u := range activeUsers {
+		email := emailKey(u)
+		notes := buildNotes(u) // TODO: pass metadata when step 4 is implemented
+
+		snipeUser, err := s.snipe.FindUserByEmail(ctx, email)
+		if err != nil {
+			slog.Warn("error looking up Snipe-IT user", "email", email, "error", err)
+			result.Warnings++
+			continue
+		}
+		if snipeUser == nil {
+			if !s.config.CreateUsers {
+				slog.Warn("no Snipe-IT user found for source user", "email", email)
+				result.UnmatchedEmails = append(result.UnmatchedEmails, email)
+				result.Warnings++
+				continue
+			}
+			// TODO: derive first/last name from vendor user fields.
+			// Example: firstName, lastName := splitName(u.DisplayName, email)
+			if s.config.DryRun {
+				slog.Info("[dry-run] would create Snipe-IT user", "email", email)
+				result.UsersCreated++
+				result.CheckedOut++
+				continue
+			}
+			// TODO: call s.snipe.CreateUser with appropriate fields.
+			// created, err := s.snipe.CreateUser(ctx, firstName, lastName, email, email, "", "")
+			// if err != nil {
+			//     slog.Warn("failed to create Snipe-IT user", "email", email, "error", err)
+			//     result.Warnings++
+			//     continue
+			// }
+			// snipeUser = created
+			// result.UsersCreated++
+		}
+
+		if existing, ok := checkedOutByEmail[email]; ok {
+			if existing.Notes == notes && !s.config.Force {
+				slog.Debug("seat up to date", "email", email)
+				result.Skipped++
+				continue
+			}
+			slog.Info("updating seat notes", "email", email, "dry_run", s.config.DryRun)
+			if !s.config.DryRun {
+				if err := s.snipe.UpdateSeatNotes(ctx, lic.ID, existing.ID, notes); err != nil {
+					slog.Warn("failed to update seat notes", "email", email, "error", err)
+					result.Warnings++
+					continue
+				}
+			}
+			result.NotesUpdated++
+			continue
+		}
+
+		if s.config.DryRun {
+			slog.Info("[dry-run] would check out seat", "email", email, "notes", notes)
+			result.CheckedOut++
+			continue
+		}
+		if len(freeSeats) == 0 {
+			slog.Warn("no free seats available", "email", email)
+			result.Warnings++
+			continue
+		}
+		seat := freeSeats[0]
+		freeSeats = freeSeats[1:]
+
+		slog.Info("checking out seat", "email", email, "seat_id", seat.ID)
+		if err := s.snipe.CheckoutSeat(ctx, lic.ID, seat.ID, snipeUser.ID, notes); err != nil {
+			slog.Warn("failed to checkout seat", "email", email, "error", err)
+			freeSeats = append(freeSeats, seat) // return on failure
+			result.Warnings++
+			continue
+		}
+		result.CheckedOut++
+	}
+
+	// 10. Checkin loop — skip when --email filter is set.
+	if emailFilter == "" {
+		for email, seat := range checkedOutByEmail {
+			if _, active := activeEmails[email]; active {
+				continue
+			}
+			slog.Info("checking in seat for inactive user", "email", email, "seat_id", seat.ID, "dry_run", s.config.DryRun)
+			if !s.config.DryRun {
+				if err := s.snipe.CheckinSeat(ctx, lic.ID, seat.ID); err != nil {
+					slog.Warn("failed to checkin seat", "email", email, "error", err)
+					result.Warnings++
+					continue
+				}
+			}
+			result.CheckedIn++
+		}
+	}
+
+	return result, nil
+}
+
+// emailKey returns the canonical (lowercased) email for a user.
+// TODO: update to match your vendor's user struct fields.
+// Prefer the primary email field; fall back to username/login.
+func emailKey(u vendor.User) string { // TODO: replace vendor.User with your type
+	if u.Email != "" {
+		return strings.ToLower(u.Email)
+	}
+	return strings.ToLower(u.Username)
+}
+
+// buildNotes returns the formatted notes string written to the Snipe-IT seat.
+// TODO: replace with your vendor's metadata. Sort multi-value fields alphabetically.
+// Return an empty string if there is nothing to record.
+func buildNotes(u vendor.User) string { // TODO: update signature to accept metadata
+	return ""
+}
+```

--- a/docs/snipeit-api.md
+++ b/docs/snipeit-api.md
@@ -1,0 +1,214 @@
+# Snipe-IT API & Sync Flow
+
+---
+
+## Snipe-IT API
+
+### Envelope behavior
+
+- **POST / PATCH** responses are wrapped: `{ "status": "success", "messages": {}, "payload": { ... } }`
+- **GET** responses are the object directly (no envelope).
+- Always check `env.Status == "success"` after POST/PATCH — a 200 response can
+  still carry `"status": "error"` with validation messages. This applies to
+  `CreateLicense`, `CreateManufacturer`, `CheckoutSeat`, and any other mutating
+  call. Decoding without this check will silently accept failed operations.
+
+### Rate limiting
+
+- Rate-limit all Snipe-IT calls via the `rateLimitMs` parameter passed to `snipeit.NewClient`.
+  Default is 500ms (2 req/s); configurable via `sync.rate_limit_ms` in settings or
+  `SNIPE_RATE_LIMIT_MS` env var. Reduce for local instances; increase if you encounter 429s.
+- Apply the limiter in the shared HTTP helpers (`get`, `post`, `patch`, the delete
+  helper), not at the method level, so it is always enforced regardless of which
+  method is called.
+
+### Checkout / checkin
+
+- `CheckoutSeat` uses **PATCH** on `/api/v1/licenses/{id}/seats/{seatID}` — POST
+  returns 405. Always use PATCH for seat assignment. The PATCH body must use
+  `"assigned_to": <userID>` (integer) to assign the user.
+- `CheckinSeat` uses **PATCH** on `/api/v1/licenses/{id}/seats/{seatID}` with
+  body `{"assigned_to": null, "asset_id": null}`. Snipe-IT does **not** support
+  DELETE on license seats — DELETE returns an error. Clearing the assignment via
+  PATCH is the correct and only supported way to check a seat back in.
+- `ListLicenseSeats` returns up to 500 rows (`?limit=500`). If a license could
+  have more than 500 assigned users, pagination is required.
+
+### Seat listing response — `assigned_user` vs `assigned_to`
+
+The `GET /api/v1/licenses/{id}/seats` response uses **`assigned_user`** (not
+`assigned_to`) as the JSON field name for the user object. The field is a nested
+object (`{"id": N, "name": "...", "email": "..."}`) or `null` when the seat is
+free. The Go struct tag must be `json:"assigned_user"`.
+
+The PATCH checkout/checkin request body uses `"assigned_to"` (integer for assign,
+null for release). These two field names are intentionally different — `assigned_user`
+is the read field on GET, `assigned_to` is the write field on PATCH.
+
+Do not confuse them — using `"assigned_to"` as the JSON tag on the struct will
+silently decode all seats as unassigned (nil) on every sync, causing full
+re-checkout of all seats on every run.
+
+### POST response returns free_seats_count: 0
+
+Snipe-IT's `POST /api/v1/licenses` (create) response returns `free_seats_count: 0`
+regardless of the seat count. Do **not** use `lic.FreeSeatsCount` from a create
+response to drive ghost detection — ghost cleanup will compute `ghostCount = seats - 0 = N`
+and drain the entire free seat pool before the checkout loop runs.
+
+Always refresh the license with `FindLicenseByID` (a GET) after create or expand
+before reading `FreeSeatsCount`. See step 7.5 in the standard sync flow below.
+
+### Ghost checkout cleanup
+
+"Ghost" checkouts are seats Snipe-IT internally counts as used (tracked via
+`lic.Seats - lic.FreeSeatsCount`) but whose `assigned_user` is null in the seat
+listing. This can happen when seats were checked out via the Snipe-IT UI and the
+user was later removed through a mechanism that didn't properly check the seat in.
+
+Detect and clean up ghosts after loading seat state:
+
+```go
+snipeCheckedOut := lic.Seats - lic.FreeSeatsCount
+ghostCount := snipeCheckedOut - len(checkedOutByEmail)
+if ghostCount > 0 {
+    // clean up ghostCount seats from freeSeats using CheckinSeat
+}
+```
+
+The PATCH checkin (`{"assigned_to": null, "asset_id": null}`) correctly resolves
+the ghost state by clearing Snipe-IT's internal assignment record.
+
+### FindOrCreate pattern
+
+- `FindOrCreate*` methods first search by exact name, then create if not found.
+- Search endpoints may return fuzzy/partial matches — always verify with
+  `strings.EqualFold` before treating a row as the match.
+- `license_category_id` is required by Snipe-IT when creating a license. Validate
+  it is non-zero before any API calls and fail with a clear error message.
+
+### User creation (`--create-users`)
+
+When a source user has no matching Snipe-IT account, the `--create-users` flag
+triggers `CreateUser` instead of warning and skipping. Created users are populated
+from source system data and configured to be inert within Snipe-IT:
+
+- `activated: false` — user cannot log into Snipe-IT
+- `send_welcome: false` — no welcome email is sent
+- No group membership — avoids any auto-assign license groups
+- `start_date` — set to the account creation date in the source system (when
+  available), formatted as `YYYY-MM-DD`
+- `notes` — documents the auto-creation source (e.g. "Auto-created from
+  `<source system>` via `<integration name>`")
+- `password` — cryptographically random, unusable in practice since `activated`
+  is false; required by the Snipe-IT API
+
+`CreateUser` POSTs to `/api/v1/users`. The response is wrapped in the standard
+envelope (`status`, `messages`, `payload`). Always check `env.Status == "success"`
+before unmarshaling the payload.
+
+The `Result.UsersCreated` counter tracks how many accounts were created. In
+dry-run, creation is simulated (logged as `[dry-run] would create Snipe-IT user`)
+and the counter is still incremented so output is meaningful.
+
+Unmatched users whose creation fails are counted as `Warnings` (not added to
+`UnmatchedEmails`) — the Slack notification path for unmatched emails is bypassed
+since the failure is already logged.
+
+Source system data needed for `CreateUser` (display name, account creation date)
+typically requires an additional API scope or endpoint beyond what the basic sync
+needs. Gate the extra API call behind the `--create-users` flag rather than
+fetching it unconditionally — see the integration's `CONTEXT.md` for specifics.
+
+### Seat state partitioning
+
+Partition the slice from `ListLicenseSeats` into two structures:
+- `checkedOutByEmail map[string]*LicenseSeat` — key is `strings.ToLower(seat.AssignedTo.Email)`
+- `freeSeats []*LicenseSeat` — seats with nil or empty `AssignedTo`
+
+After partitioning, run the ghost cleanup pass (see above) before the checkout loop.
+
+If a checkout call fails, return the seat to `freeSeats` before continuing.
+Seats are never shrunk automatically — only ever expanded.
+
+---
+
+## Standard sync flow
+
+The sync runs in two passes. The pattern below is vendor-agnostic; vendor-specific
+steps (role fetching, manufacturer resolution, etc.) are described in `CONTEXT.md`.
+
+**Checkout/update pass** (runs for all users, or one user with `--email`):
+
+1. Fetch active users from the source system (paginated).
+2. Build an active email set for use in the checkin pass.
+3. Apply `--email` filter if set.
+4. Fetch per-user metadata from the source system (roles, groups, etc.).
+5. Resolve any Snipe-IT entities needed before license creation (manufacturer, etc.).
+6. Resolve target seat count: vendor API → `snipe_it.license_seats` config → active member count (floor).
+   Find or create the Snipe-IT license (dry-run: find only; synthesize if absent).
+7. Expand license seat count if `targetSeats > license.Seats`.
+7.5. **Refresh the license with `FindLicenseByID`** — the POST response has `free_seats_count: 0`;
+   the GET response has the real value. Required before ghost detection.
+8. Load current seat assignments; partition into `checkedOutByEmail` and `freeSeats`.
+   Run ghost cleanup before the checkout loop.
+9. For each active user:
+   - Look up the Snipe-IT user by email.
+   - If not found and `--create-users` is set: call `CreateUser` (see User creation
+     section above); increment `UsersCreated`; continue to checkout. In dry-run,
+     log the would-be creation and count `CheckedOut`; skip the real checkout.
+   - If not found and `--create-users` is not set: warn + skip + append to
+     `result.UnmatchedEmails`.
+   - If already checked out: compare notes; update if changed or `--force`.
+   - If not checked out: pop a free seat and call `CheckoutSeat`.
+
+**Checkin pass** (skipped when `--email` filter is active):
+
+10. For each seat whose assigned email is not in the active set: call `CheckinSeat`.
+
+### Result struct
+
+```go
+type Result struct {
+    CheckedOut      int      // seats newly assigned
+    NotesUpdated    int      // seats whose notes were updated
+    CheckedIn       int      // seats returned for inactive users
+    Skipped         int      // users already up to date
+    Warnings        int      // users with no matching Snipe-IT account, or API errors
+    UsersCreated    int      // new Snipe-IT users created (--create-users)
+    UnmatchedEmails []string // source users with no corresponding Snipe-IT account
+}
+```
+
+### User matching
+
+Match source system users to Snipe-IT users by **lowercased email address**.
+Prefer the primary email field; fall back to the login/username field. All
+comparisons must use `strings.ToLower` — never compare email addresses
+case-sensitively.
+
+### Notes field
+
+Write per-user metadata from the source system into the seat's `notes` field.
+Sort multi-value fields (e.g. role labels) alphabetically. Use an empty string
+if there is nothing to record. Compare notes before patching — skip unchanged
+seats (unless `--force`).
+
+---
+
+## Slack notifications (internal/slack/client.go)
+
+- Minimal stdlib-only webhook client (`net/http`). No external dependencies.
+- `Send(ctx, text)` is a no-op if `webhook_url` is empty — the binary works
+  without any Slack configuration.
+- Slack errors are logged as warnings via `slog.Warn`; they never fail the
+  sync command.
+- **Keep the sync package free of Slack dependencies.** Collect unmatched user
+  emails in `Result.UnmatchedEmails` during the sync; send notifications from
+  `cmd/sync.go` after `syncer.Run()` returns.
+- Three events trigger notifications, all suppressed in dry-run:
+  1. **Sync failure** — send after logging the error, before returning it.
+  2. **Unmatched users** — one message per email in `result.UnmatchedEmails`.
+  3. **Sync success** — send after printing the result summary line.
+- Configuration: `slack.webhook_url` in `settings.yaml`, overridable via
+  `SLACK_WEBHOOK` env var (bind in `cmd/root.go` `initConfig()`).

--- a/docs/source-files.md
+++ b/docs/source-files.md
@@ -1,0 +1,608 @@
+# Vendor-agnostic source files
+
+These files are identical across all integrations. Copy them verbatim — no
+modifications required.
+
+---
+
+## internal/snipeit/client.go
+
+```go
+package snipeit
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// Client is a Snipe-IT REST API client, rate-limited to 2 req/s.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+	limiter    *rate.Limiter
+}
+
+func NewClient(baseURL, apiKey string, rateLimitMs int) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		limiter: rate.NewLimiter(rate.Every(time.Duration(rateLimitMs)*time.Millisecond), 1),
+	}
+}
+
+// --- Types ---
+
+type License struct {
+	ID             int    `json:"id"`
+	Name           string `json:"name"`
+	Seats          int    `json:"seats"`
+	FreeSeatsCount int    `json:"free_seats_count"`
+}
+
+type AssignedTo struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}
+
+type LicenseSeat struct {
+	ID         int         `json:"id"`
+	LicenseID  int         `json:"license_id"`
+	AssignedTo *AssignedTo `json:"assigned_user"` // GET response uses "assigned_user", not "assigned_to"
+	Notes      string      `json:"notes"`
+}
+
+type SnipeUser struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}
+
+type Manufacturer struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type Supplier struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// NewSupplier holds the fields used when creating a supplier record.
+// All fields except Name are optional — empty strings are omitted from the request.
+type NewSupplier struct {
+	Name     string
+	URL      string
+	Address  string
+	Address2 string
+	City     string
+	State    string
+	Zip      string
+	Country  string
+	Phone    string
+	Notes    string
+}
+
+// --- envelope types for POST/PATCH responses ---
+
+type envelope struct {
+	Status  string          `json:"status"`
+	Message json.RawMessage `json:"messages"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+type licenseListResponse struct {
+	Total int       `json:"total"`
+	Rows  []License `json:"rows"`
+}
+
+type seatListResponse struct {
+	Total int           `json:"total"`
+	Rows  []LicenseSeat `json:"rows"`
+}
+
+type userListResponse struct {
+	Total int         `json:"total"`
+	Rows  []SnipeUser `json:"rows"`
+}
+
+type manufacturerListResponse struct {
+	Total int            `json:"total"`
+	Rows  []Manufacturer `json:"rows"`
+}
+
+type supplierListResponse struct {
+	Total int        `json:"total"`
+	Rows  []Supplier `json:"rows"`
+}
+
+// --- License methods ---
+
+// FindLicenseByName searches for a license by exact name. Returns nil, nil if not found.
+func (c *Client) FindLicenseByName(ctx context.Context, name string) (*License, error) {
+	endpoint := fmt.Sprintf("/api/v1/licenses?search=%s&limit=50", url.QueryEscape(name))
+	var result licenseListResponse
+	if err := c.get(ctx, endpoint, &result); err != nil {
+		return nil, err
+	}
+	for i := range result.Rows {
+		if strings.EqualFold(result.Rows[i].Name, name) {
+			return &result.Rows[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// FindLicenseByID fetches a license by numeric ID.
+func (c *Client) FindLicenseByID(ctx context.Context, id int) (*License, error) {
+	var lic License
+	if err := c.get(ctx, fmt.Sprintf("/api/v1/licenses/%d", id), &lic); err != nil {
+		return nil, err
+	}
+	return &lic, nil
+}
+
+// CreateLicense creates a new license record. categoryID is required. manufacturerID
+// and supplierID are optional — pass 0 to omit them from the request.
+func (c *Client) CreateLicense(ctx context.Context, name string, seats, categoryID, manufacturerID, supplierID int) (*License, error) {
+	body := map[string]any{"name": name, "seats": seats, "category_id": categoryID}
+	if manufacturerID != 0 {
+		body["manufacturer_id"] = manufacturerID
+	}
+	if supplierID != 0 {
+		body["supplier_id"] = supplierID
+	}
+	var env envelope
+	if err := c.post(ctx, "/api/v1/licenses", body, &env); err != nil {
+		return nil, err
+	}
+	if env.Status != "success" {
+		return nil, fmt.Errorf("snipeit CreateLicense: status=%q messages=%s", env.Status, string(env.Message))
+	}
+	var lic License
+	if err := json.Unmarshal(env.Payload, &lic); err != nil {
+		return nil, fmt.Errorf("snipeit CreateLicense: unmarshal payload: %w", err)
+	}
+	return &lic, nil
+}
+
+// FindOrCreateLicense finds the license by name, creating it if absent.
+// categoryID is required; manufacturerID and supplierID are optional (pass 0 to omit).
+func (c *Client) FindOrCreateLicense(ctx context.Context, name string, initialSeats, categoryID, manufacturerID, supplierID int) (*License, error) {
+	lic, err := c.FindLicenseByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if lic != nil {
+		return lic, nil
+	}
+	return c.CreateLicense(ctx, name, initialSeats, categoryID, manufacturerID, supplierID)
+}
+
+// --- Manufacturer methods ---
+
+// FindManufacturerByName searches for a manufacturer by exact name. Returns nil, nil if not found.
+func (c *Client) FindManufacturerByName(ctx context.Context, name string) (*Manufacturer, error) {
+	endpoint := fmt.Sprintf("/api/v1/manufacturers?search=%s&limit=50", url.QueryEscape(name))
+	var result manufacturerListResponse
+	if err := c.get(ctx, endpoint, &result); err != nil {
+		return nil, err
+	}
+	for i := range result.Rows {
+		if strings.EqualFold(result.Rows[i].Name, name) {
+			return &result.Rows[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// CreateManufacturer creates a new manufacturer record.
+func (c *Client) CreateManufacturer(ctx context.Context, name, mfrURL string) (*Manufacturer, error) {
+	body := map[string]any{"name": name, "url": mfrURL}
+	var env envelope
+	if err := c.post(ctx, "/api/v1/manufacturers", body, &env); err != nil {
+		return nil, err
+	}
+	if env.Status != "success" {
+		return nil, fmt.Errorf("snipeit CreateManufacturer: status=%q messages=%s", env.Status, string(env.Message))
+	}
+	var mfr Manufacturer
+	if err := json.Unmarshal(env.Payload, &mfr); err != nil {
+		return nil, fmt.Errorf("snipeit CreateManufacturer: unmarshal payload: %w", err)
+	}
+	return &mfr, nil
+}
+
+// FindOrCreateManufacturer finds a manufacturer by name, creating it if absent.
+func (c *Client) FindOrCreateManufacturer(ctx context.Context, name, mfrURL string) (*Manufacturer, error) {
+	mfr, err := c.FindManufacturerByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if mfr != nil {
+		return mfr, nil
+	}
+	return c.CreateManufacturer(ctx, name, mfrURL)
+}
+
+// --- Supplier methods ---
+
+// FindSupplierByName searches for a supplier by exact name. Returns nil, nil if not found.
+func (c *Client) FindSupplierByName(ctx context.Context, name string) (*Supplier, error) {
+	endpoint := fmt.Sprintf("/api/v1/suppliers?search=%s&limit=50", url.QueryEscape(name))
+	var result supplierListResponse
+	if err := c.get(ctx, endpoint, &result); err != nil {
+		return nil, err
+	}
+	for i := range result.Rows {
+		if strings.EqualFold(result.Rows[i].Name, name) {
+			return &result.Rows[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// CreateSupplier creates a new supplier record. Only Name is required;
+// all other fields in NewSupplier are omitted from the request when empty.
+func (c *Client) CreateSupplier(ctx context.Context, s NewSupplier) (*Supplier, error) {
+	body := map[string]any{"name": s.Name}
+	if s.URL != "" {
+		body["url"] = s.URL
+	}
+	if s.Address != "" {
+		body["address"] = s.Address
+	}
+	if s.Address2 != "" {
+		body["address2"] = s.Address2
+	}
+	if s.City != "" {
+		body["city"] = s.City
+	}
+	if s.State != "" {
+		body["state"] = s.State
+	}
+	if s.Zip != "" {
+		body["zip"] = s.Zip
+	}
+	if s.Country != "" {
+		body["country"] = s.Country
+	}
+	if s.Phone != "" {
+		body["phone"] = s.Phone
+	}
+	if s.Notes != "" {
+		body["notes"] = s.Notes
+	}
+	var env envelope
+	if err := c.post(ctx, "/api/v1/suppliers", body, &env); err != nil {
+		return nil, err
+	}
+	if env.Status != "success" {
+		return nil, fmt.Errorf("snipeit CreateSupplier: status=%q messages=%s", env.Status, string(env.Message))
+	}
+	var sup Supplier
+	if err := json.Unmarshal(env.Payload, &sup); err != nil {
+		return nil, fmt.Errorf("snipeit CreateSupplier: unmarshal payload: %w", err)
+	}
+	return &sup, nil
+}
+
+// FindOrCreateSupplier finds a supplier by name, creating it if absent.
+func (c *Client) FindOrCreateSupplier(ctx context.Context, s NewSupplier) (*Supplier, error) {
+	sup, err := c.FindSupplierByName(ctx, s.Name)
+	if err != nil {
+		return nil, err
+	}
+	if sup != nil {
+		return sup, nil
+	}
+	return c.CreateSupplier(ctx, s)
+}
+
+// UpdateLicenseSeats changes the seat count on an existing license.
+func (c *Client) UpdateLicenseSeats(ctx context.Context, licenseID, seats int) (*License, error) {
+	body := map[string]any{"seats": seats}
+	var env envelope
+	if err := c.patch(ctx, fmt.Sprintf("/api/v1/licenses/%d", licenseID), body, &env); err != nil {
+		return nil, err
+	}
+	var lic License
+	if err := json.Unmarshal(env.Payload, &lic); err != nil {
+		return nil, fmt.Errorf("snipeit UpdateLicenseSeats: unmarshal payload: %w", err)
+	}
+	return &lic, nil
+}
+
+// --- Seat methods ---
+
+// ListLicenseSeats returns all seats for a license (up to 500).
+func (c *Client) ListLicenseSeats(ctx context.Context, licenseID int) ([]LicenseSeat, error) {
+	var result seatListResponse
+	if err := c.get(ctx, fmt.Sprintf("/api/v1/licenses/%d/seats?limit=500", licenseID), &result); err != nil {
+		return nil, err
+	}
+	return result.Rows, nil
+}
+
+// CheckoutSeat assigns a seat to a Snipe-IT user via PATCH (POST returns 405).
+// The PATCH body uses "assigned_to" (integer) — note this differs from the GET
+// response field "assigned_user". See snipeit-api.md for details.
+func (c *Client) CheckoutSeat(ctx context.Context, licenseID, seatID, userID int, notes string) error {
+	body := map[string]any{
+		"assigned_to": userID,
+		"notes":       notes,
+	}
+	var env envelope
+	if err := c.patch(ctx, fmt.Sprintf("/api/v1/licenses/%d/seats/%d", licenseID, seatID), body, &env); err != nil {
+		return err
+	}
+	if env.Status != "success" {
+		return fmt.Errorf("snipeit CheckoutSeat license=%d seat=%d: status=%q messages=%s", licenseID, seatID, env.Status, string(env.Message))
+	}
+	return nil
+}
+
+// CheckinSeat returns a seat by PATCHing assigned_to and asset_id to null.
+// Snipe-IT does not support DELETE on license seats; clearing the assignment
+// via PATCH is the correct way to check a seat back in.
+func (c *Client) CheckinSeat(ctx context.Context, licenseID, seatID int) error {
+	body := map[string]any{
+		"assigned_to": nil,
+		"asset_id":    nil,
+	}
+	var env envelope
+	if err := c.patch(ctx, fmt.Sprintf("/api/v1/licenses/%d/seats/%d", licenseID, seatID), body, &env); err != nil {
+		return err
+	}
+	if env.Status != "success" {
+		return fmt.Errorf("snipeit CheckinSeat license=%d seat=%d: status=%q messages=%s", licenseID, seatID, env.Status, string(env.Message))
+	}
+	return nil
+}
+
+// UpdateSeatNotes patches the notes field on an existing checkout.
+func (c *Client) UpdateSeatNotes(ctx context.Context, licenseID, seatID int, notes string) error {
+	body := map[string]any{"notes": notes}
+	var env envelope
+	return c.patch(ctx, fmt.Sprintf("/api/v1/licenses/%d/seats/%d", licenseID, seatID), body, &env)
+}
+
+// --- User methods ---
+
+// FindUserByID fetches a Snipe-IT user by numeric ID.
+func (c *Client) FindUserByID(ctx context.Context, id int) (*SnipeUser, error) {
+	var u SnipeUser
+	if err := c.get(ctx, fmt.Sprintf("/api/v1/users/%d", id), &u); err != nil {
+		return nil, err
+	}
+	return &u, nil
+}
+
+// FindUserByEmail searches Snipe-IT users by email. Returns nil, nil if not found.
+func (c *Client) FindUserByEmail(ctx context.Context, email string) (*SnipeUser, error) {
+	endpoint := fmt.Sprintf("/api/v1/users?search=%s&limit=50", url.QueryEscape(email))
+	var result userListResponse
+	if err := c.get(ctx, endpoint, &result); err != nil {
+		return nil, err
+	}
+	needle := strings.ToLower(email)
+	for i := range result.Rows {
+		if strings.ToLower(result.Rows[i].Email) == needle {
+			return &result.Rows[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// CreateUser creates a new Snipe-IT user. The user is created with login
+// disabled (activated=false), no welcome email, and no auto-assign license
+// group membership. startDate must be "YYYY-MM-DD" or empty to omit.
+func (c *Client) CreateUser(ctx context.Context, firstName, lastName, email, username, notes, startDate string) (*SnipeUser, error) {
+	pw, err := randomPassword()
+	if err != nil {
+		return nil, fmt.Errorf("snipeit CreateUser: generating password: %w", err)
+	}
+	body := map[string]any{
+		"first_name":            firstName,
+		"last_name":             lastName,
+		"email":                 email,
+		"username":              username,
+		"password":              pw,
+		"password_confirmation": pw,
+		"activated":             false,
+		"send_welcome":          false,
+		"notes":                 notes,
+	}
+	if startDate != "" {
+		body["start_date"] = startDate
+	}
+	var env envelope
+	if err := c.post(ctx, "/api/v1/users", body, &env); err != nil {
+		return nil, err
+	}
+	if env.Status != "success" {
+		return nil, fmt.Errorf("snipeit CreateUser: status=%q messages=%s", env.Status, string(env.Message))
+	}
+	var u SnipeUser
+	if err := json.Unmarshal(env.Payload, &u); err != nil {
+		return nil, fmt.Errorf("snipeit CreateUser: unmarshal payload: %w", err)
+	}
+	return &u, nil
+}
+
+// randomPassword generates a cryptographically random 32-hex-character password.
+func randomPassword() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// --- HTTP helpers ---
+
+func (c *Client) get(ctx context.Context, path string, out any) error {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	req, err := c.newRequest(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("snipeit GET %s: status %d", path, resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+func (c *Client) post(ctx context.Context, path string, body any, out any) error {
+	return c.writeRequest(ctx, http.MethodPost, path, body, out)
+}
+
+func (c *Client) patch(ctx context.Context, path string, body any, out any) error {
+	return c.writeRequest(ctx, http.MethodPatch, path, body, out)
+}
+
+func (c *Client) writeRequest(ctx context.Context, method, path string, body any, out any) error {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return err
+	}
+	b, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := c.newRequest(ctx, method, c.baseURL+path, bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("snipeit %s %s: status %d", method, path, resp.StatusCode)
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}
+
+func (c *Client) newRequest(ctx context.Context, method, url string, body *bytes.Reader) (*http.Request, error) {
+	var req *http.Request
+	var err error
+	if body != nil {
+		req, err = http.NewRequestWithContext(ctx, method, url, body)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, url, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Accept", "application/json")
+	return req, nil
+}
+```
+
+---
+
+## internal/slack/client.go
+
+```go
+package slack
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Client sends messages to a Slack incoming webhook URL.
+// All methods are no-ops if WebhookURL is empty.
+type Client struct {
+	webhookURL string
+	httpClient *http.Client
+}
+
+// NewClient returns a new Client. If webhookURL is empty, all Send calls
+// are silently ignored.
+func NewClient(webhookURL string) *Client {
+	return &Client{
+		webhookURL: webhookURL,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// Send posts a plain-text message to the configured webhook. Returns nil
+// immediately if no webhook URL is set.
+func (c *Client) Send(ctx context.Context, text string) error {
+	if c.webhookURL == "" {
+		return nil
+	}
+	body, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("slack webhook: unexpected status %d", resp.StatusCode)
+	}
+	return nil
+}
+```
+
+---
+
+## internal/sync/result.go
+
+```go
+package sync
+
+// Result summarises what happened during a sync run.
+type Result struct {
+	CheckedOut      int      // seats newly assigned
+	NotesUpdated    int      // seats whose notes were updated
+	CheckedIn       int      // seats returned for inactive users
+	Skipped         int      // users already up to date
+	Warnings        int      // users with no matching Snipe-IT account, or API errors
+	UsersCreated    int      // new Snipe-IT users created (--create-users)
+	UnmatchedEmails []string // source users with no corresponding Snipe-IT account
+}
+```


### PR DESCRIPTION
## Summary

- **macOS code signing + notarization**: Release workflow restructured into three parallel jobs (`build-macos`, `build-other`, `release`). Darwin binaries are now signed with Developer ID and submitted to Apple's notarization service via App Store Connect API key. Fixes the Gatekeeper/quarantine block that prevented running downloaded binaries on macOS without an `xattr` workaround.
- **Integration scaffolding docs migrated**: `release.md`, `scaffolding.md`, `source-files.md`, and `snipeit-api.md` moved from the private `2snipe-config` parent repo into `docs/` here, so contributors building new `*2snipe` integrations have everything in one place. README Contributing section updated with a separate track for integration builders.
- **Doc accuracy fixes**: Go 1.22 → 1.25 throughout; `go.mod` template versions updated (cobra v1.10.2, viper v1.21.0); version history typos in `docs/order-of-operations.md` (`v1.0.0` → `v1.1.0`); README install step changed from prose to explicit `sudo install -m 755` command.
- **Scaffolding template bug fix**: `docs/scaffolding.md` `cmd/root.go` template had `SilenceUsage = true` in `PersistentPreRunE`, which also suppresses usage on missing-arg errors. Replaced with the `silentUsage()` wrapper + `fatal()` helper pattern.

## Required secrets (one-time setup, already configured)

Five repository secrets must be set for the macOS signing job to succeed:

| Secret | Description |
|--------|-------------|
| `APPLE_CERT_P12` | Base64-encoded Developer ID Application certificate (.p12) |
| `APPLE_CERT_PASSWORD` | Password for the .p12 file |
| `APPLE_API_KEY` | Base64-encoded App Store Connect API key (.p8) |
| `APPLE_API_KEY_ID` | App Store Connect API key ID |
| `APPLE_API_ISSUER_ID` | App Store Connect issuer ID |

## Test plan

- [ ] Merge this PR
- [ ] Tag `v1.1.1` to trigger the release workflow
- [ ] Confirm all three jobs complete successfully in Actions
- [ ] Download `snipemgr-darwin-arm64` from the release, run `spctl --assess --verbose snipemgr-darwin-arm64` — should pass with `accepted` (Gatekeeper-notarized)
- [ ] Confirm `checksums.txt` is present in the release assets

## Relates to

- Relates to #13 (checksum verification) — `checksums.txt` is now generated in the release job (prerequisite fulfilled)