### PR TITLE
fix: rename Artifact Registry repo to snipe-integrations, add Cloud Build option, fix init timezone prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ snipemgr status
 - The [`gcloud` CLI](https://cloud.google.com/sdk/docs/install) installed and authenticated
 - See [GCP setup](#gcp-setup-required-for---secrets-backend-gcp) below
 
+**To build container images for Cloud Run Jobs** — choose one:
+- [Docker](https://docs.docker.com/get-docker/) installed and running locally, **or**
+- Cloud Build API enabled (`gcloud services enable cloudbuild.googleapis.com`) — no local Docker required
+
 **To build from source** — Go 1.25+
 
 **GitHub token (optional)** — without one, GitHub rate-limits API calls to 60/hr. Sufficient for occasional use but tight if you run `snipemgr list` frequently. Set `registry.github_token` in `snipemgr.yaml` with a token scoped to `public_repo` (or `repo` for private integration repos).
@@ -185,25 +189,19 @@ gcp:
 
 ## Building container images for Cloud Run Jobs
 
-Cloud Run Jobs require a Docker image in Artifact Registry. This is a one-time step per integration. Run `snipemgr run <name>` after installing — it prints these instructions automatically if no image exists yet.
+Cloud Run Jobs require a container image in Artifact Registry. This is a one-time step per integration. Run `snipemgr run <name>` after installing — it prints these instructions automatically if no image exists yet.
 
 **1. Create the Artifact Registry repository** (one-time per project):
 
 ```bash
-gcloud artifacts repositories create 2snipe \
+gcloud artifacts repositories create snipe-integrations \
   --repository-format=docker \
   --location=us-central1 \
   --project=YOUR_PROJECT_ID \
-  --description="2snipe integration images"
+  --description="snipe-integrations container images"
 ```
 
-**2. Authenticate Docker**:
-
-```bash
-gcloud auth configure-docker us-central1-docker.pkg.dev
-```
-
-**3. Build and push the integration image** (example: `github2snipe`):
+**2. Clone the integration source** (example: `github2snipe`):
 
 ```bash
 git clone https://github.com/jackvaughanjr/github2snipe.git
@@ -223,16 +221,26 @@ COPY --from=builder /app/github2snipe /app/github2snipe
 ENTRYPOINT ["/app/github2snipe"]
 ```
 
-Then build and push:
+**3. Build and push** — choose one method:
 
+**Option A — Docker** (requires Docker installed and running):
 ```bash
-docker build -t us-central1-docker.pkg.dev/YOUR_PROJECT_ID/2snipe/github2snipe:latest .
-docker push us-central1-docker.pkg.dev/YOUR_PROJECT_ID/2snipe/github2snipe:latest
+gcloud auth configure-docker us-central1-docker.pkg.dev
+docker build -t us-central1-docker.pkg.dev/YOUR_PROJECT_ID/snipe-integrations/github2snipe:latest .
+docker push us-central1-docker.pkg.dev/YOUR_PROJECT_ID/snipe-integrations/github2snipe:latest
+```
+
+**Option B — Cloud Build** (no Docker required — builds and pushes via GCP):
+```bash
+gcloud services enable cloudbuild.googleapis.com --project=YOUR_PROJECT_ID
+gcloud builds submit \
+  --tag us-central1-docker.pkg.dev/YOUR_PROJECT_ID/snipe-integrations/github2snipe:latest \
+  --project=YOUR_PROJECT_ID .
 ```
 
 Replace `YOUR_PROJECT_ID` and `github2snipe` with your project and integration name. The image path pattern is:
 ```
-{region}-docker.pkg.dev/{project}/2snipe/{integration-name}:latest
+{region}-docker.pkg.dev/{project}/snipe-integrations/{integration-name}:latest
 ```
 
 After pushing, trigger the job:

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -143,6 +143,7 @@ func runInit(_ *cobra.Command, _ []string) error {
 	gcpProject := ""
 	gcpRegion := "us-central1"
 	gcpSA := ""
+	gcpTimezone := "UTC"
 	if configureGCP {
 		if err := huh.NewForm(huh.NewGroup(
 			huh.NewInput().
@@ -156,6 +157,18 @@ func runInit(_ *cobra.Command, _ []string) error {
 				Title("Service account email").
 				Description("e.g. snipemgr-runner@your-project-id.iam.gserviceaccount.com").
 				Value(&gcpSA),
+			huh.NewSelect[string]().
+				Title("Schedule timezone").
+				Description("Timezone used to interpret cron schedules for Cloud Scheduler triggers.").
+				Options(
+					huh.NewOption("UTC", "UTC"),
+					huh.NewOption("Eastern  (America/New_York)", "America/New_York"),
+					huh.NewOption("Central  (America/Chicago)", "America/Chicago"),
+					huh.NewOption("Mountain (America/Denver)", "America/Denver"),
+					huh.NewOption("Pacific  (America/Los_Angeles)", "America/Los_Angeles"),
+					huh.NewOption("Other — enter IANA name", "other"),
+				).
+				Value(&gcpTimezone),
 		)).Run(); err != nil {
 			return fatal("init: %v", err)
 		}
@@ -164,10 +177,27 @@ func runInit(_ *cobra.Command, _ []string) error {
 		if gcpRegion == "" {
 			gcpRegion = "us-central1"
 		}
+		if gcpTimezone == "other" {
+			customTZ := ""
+			if err := huh.NewForm(huh.NewGroup(
+				huh.NewInput().
+					Title("Timezone name").
+					Description("Enter a valid IANA timezone name.\n"+
+						"Examples: Europe/London, Asia/Tokyo, Australia/Sydney\n"+
+						"Full list: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones").
+					Value(&customTZ),
+			)).Run(); err != nil {
+				return fatal("init: %v", err)
+			}
+			gcpTimezone = strings.TrimSpace(customTZ)
+			if gcpTimezone == "" {
+				gcpTimezone = "UTC"
+			}
+		}
 	}
 
 	// Write snipemgr.yaml (0600: may contain credentials).
-	content := buildInitConfig(extraOwner, githubToken, snipeURL, snipeToken, gcpProject, gcpRegion, gcpSA)
+	content := buildInitConfig(extraOwner, githubToken, snipeURL, snipeToken, gcpProject, gcpRegion, gcpSA, gcpTimezone)
 	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
 		return fatal("writing %s: %v", configPath, err)
 	}
@@ -181,7 +211,7 @@ func runInit(_ *cobra.Command, _ []string) error {
 // extraOwner is an optional additional registry source; jackvaughanjr is always
 // written as the first source. Written as a string template rather than marshaled
 // YAML so inline documentation comments are preserved.
-func buildInitConfig(extraOwner, token, snipeURL, snipeToken, gcpProject, gcpRegion, gcpSA string) string {
+func buildInitConfig(extraOwner, token, snipeURL, snipeToken, gcpProject, gcpRegion, gcpSA, gcpTimezone string) string {
 	var b strings.Builder
 
 	b.WriteString("# snipemgr configuration\n")
@@ -238,7 +268,7 @@ func buildInitConfig(extraOwner, token, snipeURL, snipeToken, gcpProject, gcpReg
 	} else {
 		b.WriteString("  service_account: \"\"  # e.g. snipemgr-runner@your-project-id.iam.gserviceaccount.com\n")
 	}
-	b.WriteString("  scheduler_timezone: \"UTC\"  # IANA timezone for Cloud Scheduler cron triggers\n")
+	b.WriteString(fmt.Sprintf("  scheduler_timezone: %q  # IANA timezone for Cloud Scheduler cron triggers\n", gcpTimezone))
 	b.WriteString("\n")
 
 	// State

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -130,23 +130,18 @@ func imageInstructions(name, project, region string) string {
   Before %s can run via Cloud Run Jobs, its container image must be built
   and pushed to Artifact Registry. Follow these steps once per integration:
 
-  1. Ensure Docker is installed and running.
-
-  2. Create the Artifact Registry repository (one-time per project):
-       gcloud artifacts repositories create 2snipe \
+  1. Create the Artifact Registry repository (one-time per project):
+       gcloud artifacts repositories create snipe-integrations \
          --repository-format=docker \
          --location=%s \
          --project=%s \
-         --description="2snipe integration images"
+         --description="snipe-integrations container images"
 
-  3. Authenticate Docker with Artifact Registry:
-       gcloud auth configure-docker %s-docker.pkg.dev
-
-  4. Clone the integration source:
+  2. Clone the integration source:
        git clone %s
        cd %s
 
-  5. Create a Dockerfile (if one does not already exist):
+  3. Create a Dockerfile if one does not already exist:
        cat > Dockerfile <<'EOF'
        FROM golang:1.23-alpine AS builder
        WORKDIR /src
@@ -157,18 +152,26 @@ func imageInstructions(name, project, region string) string {
        ENTRYPOINT ["/app/%s"]
        EOF
 
-  6. Build and push the image:
+  4. Build and push — choose one method:
+
+     Option A: Docker (requires Docker installed and running)
+       gcloud auth configure-docker %s-docker.pkg.dev
        docker build -t %s .
        docker push %s
 
-  7. Re-run:
+     Option B: Cloud Build (no Docker required — builds via GCP)
+       gcloud services enable cloudbuild.googleapis.com --project=%s
+       gcloud builds submit --tag %s --project=%s .
+
+  5. Re-run:
        snipemgr run %s
 ─────────────────────────────────────────────────────────────────────────────
 `,
-		name, region, project, region,
+		name, region, project,
 		repo, name,
 		name, name, name, name,
-		image, image,
+		region, image, image,
+		project, image, project,
 		name,
 	)
 }

--- a/docs/gcp-infra.md
+++ b/docs/gcp-infra.md
@@ -121,7 +121,7 @@ missing. Phase 4+ can automate this.
 
 **Suggested Artifact Registry path:**
 ```
-{region}-docker.pkg.dev/{project}/2snipe/{name}:latest
+{region}-docker.pkg.dev/{project}/snipe-integrations/{name}:latest
 ```
 
 ---

--- a/docs/phases/phase-3-complete.md
+++ b/docs/phases/phase-3-complete.md
@@ -46,10 +46,11 @@ at install time. `enable`, `disable`, `run`, and `status` all work end to end.
 - **GCP authentication order:** Option B — ADC first, `credentials_file` fallback.
   `snipemgr.example.yaml` was updated to document the new `gcp.credentials_file`
   field (confirmed: it was missing before Phase 3).
-- **Docker image management:** Manual build+push for Phase 3. `snipemgr run`
-  prints detailed step-by-step instructions (Dockerfile template, `docker build`,
-  `docker push`) whenever an integration has never run successfully. The README
-  also has a dedicated "Building container images for Cloud Run Jobs" section.
+- **Container image management:** Manual build+push for Phase 3. `snipemgr run`
+  prints detailed step-by-step instructions (Dockerfile template, plus both
+  Docker and Cloud Build options) whenever an integration has never run
+  successfully. The README has a dedicated "Building container images for Cloud
+  Run Jobs" section documenting both approaches.
 
 ---
 

--- a/internal/scheduler/gcp.go
+++ b/internal/scheduler/gcp.go
@@ -36,7 +36,7 @@ type JobSpec struct {
 	// GCP region (e.g. "us-central1").
 	Region string
 	// Full Artifact Registry image path, e.g.
-	// "us-central1-docker.pkg.dev/my-project/2snipe/github2snipe:latest"
+	// "us-central1-docker.pkg.dev/my-project/snipe-integrations/github2snipe:latest"
 	Image string
 	// Service account email for the Cloud Run Job runtime.
 	ServiceAccount string
@@ -446,9 +446,9 @@ func executionFromProto(e *runpb.Execution) *Execution {
 }
 
 // ImagePath returns the expected Artifact Registry image path for an integration.
-// Pattern: {region}-docker.pkg.dev/{project}/2snipe/{name}:latest
+// Pattern: {region}-docker.pkg.dev/{project}/snipe-integrations/{name}:latest
 func ImagePath(project, region, name string) string {
-	return fmt.Sprintf("%s-docker.pkg.dev/%s/2snipe/%s:latest", region, project, name)
+	return fmt.Sprintf("%s-docker.pkg.dev/%s/snipe-integrations/%s:latest", region, project, name)
 }
 
 // CloudRunJobName returns the full resource name for a Cloud Run Job.

--- a/internal/scheduler/gcp_test.go
+++ b/internal/scheduler/gcp_test.go
@@ -71,7 +71,7 @@ func TestMockScheduler_CreateAndDelete(t *testing.T) {
 		Name:           "github2snipe",
 		Project:        "test-project",
 		Region:         "us-central1",
-		Image:          "us-central1-docker.pkg.dev/test-project/2snipe/github2snipe:latest",
+		Image:          "us-central1-docker.pkg.dev/test-project/snipe-integrations/github2snipe:latest",
 		ServiceAccount: "runner@test-project.iam.gserviceaccount.com",
 		Schedule:       "0 6 * * *",
 	}
@@ -101,7 +101,7 @@ func TestBuildCloudRunJobSpec_EnvVars(t *testing.T) {
 		Name:           "github2snipe",
 		Project:        "my-project",
 		Region:         "us-central1",
-		Image:          "us-central1-docker.pkg.dev/my-project/2snipe/github2snipe:latest",
+		Image:          "us-central1-docker.pkg.dev/my-project/snipe-integrations/github2snipe:latest",
 		ServiceAccount: "runner@my-project.iam.gserviceaccount.com",
 		Schedule:       "0 6 * * *",
 		ConfigFields: []registry.ConfigField{
@@ -173,7 +173,7 @@ func TestBuildSchedulerJobSpec_CronPassthrough(t *testing.T) {
 
 func TestImagePath(t *testing.T) {
 	got := scheduler.ImagePath("my-project", "us-central1", "github2snipe")
-	want := "us-central1-docker.pkg.dev/my-project/2snipe/github2snipe:latest"
+	want := "us-central1-docker.pkg.dev/my-project/snipe-integrations/github2snipe:latest"
 	if got != want {
 		t.Errorf("ImagePath = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- **Artifact Registry rename:** `2snipe` → `snipe-integrations` across all code, tests, docs, and README. GCP rejects names that start with a digit.
- **Cloud Build alternative:** Docker is no longer the only path for building container images. README requirements section, the "Building container images" section, and the `snipemgr run` inline instructions now present Docker (local) and Cloud Build (`gcloud builds submit`) as equal options.
- **`snipemgr init` timezone prompt:** The GCP step in `init` now asks for `scheduler_timezone` using the same timezone select (UTC / Eastern / Central / Mountain / Pacific / Other + free-text) as the install wizard. Previously it silently wrote `UTC`.

## Files changed

- `internal/scheduler/gcp.go` + `gcp_test.go` — image URL path updated
- `cmd/run.go` — inline missing-image instructions updated with both build options
- `cmd/init.go` — timezone prompt added to GCP block; `buildInitConfig` updated
- `README.md` — requirements section + container image section updated
- `docs/gcp-infra.md` — image path pattern updated
- `docs/phases/phase-3-complete.md` — Docker-only language softened to reflect both options

## Test plan

- [ ] `go build ./...` — passes
- [ ] `go test ./...` — all green
- [ ] `snipemgr init` with GCP → Yes: timezone select appears; chosen value written to `snipemgr.yaml`
- [ ] `snipemgr run <name>` with no image: instructions show both Docker and Cloud Build options with correct `snipe-integrations` repo name