### PR TITLE
docs: add Cloud Build IAM grant to Option B build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,11 +232,20 @@ docker push us-central1-docker.pkg.dev/YOUR_PROJECT_ID/snipe-integrations/github
 
 **Option B — Cloud Build** (no Docker required — builds and pushes via GCP):
 ```bash
+# One-time project setup:
 gcloud services enable cloudbuild.googleapis.com --project=YOUR_PROJECT_ID
+PROJECT_NUMBER=$(gcloud projects describe YOUR_PROJECT_ID --format='value(projectNumber)')
+gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+  --role="roles/cloudbuild.builds.builder"
+
+# Build and push:
 gcloud builds submit \
   --tag us-central1-docker.pkg.dev/YOUR_PROJECT_ID/snipe-integrations/github2snipe:latest \
   --project=YOUR_PROJECT_ID .
 ```
+
+> The IAM grant is required once per project. Without it Cloud Build fails with a 403 reading the source upload from Cloud Storage.
 
 Replace `YOUR_PROJECT_ID` and `github2snipe` with your project and integration name. The image path pattern is:
 ```

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -160,7 +160,13 @@ func imageInstructions(name, project, region string) string {
        docker push %s
 
      Option B: Cloud Build (no Docker required — builds via GCP)
+       # One-time project setup:
        gcloud services enable cloudbuild.googleapis.com --project=%s
+       PROJECT_NUMBER=$(gcloud projects describe %s --format='value(projectNumber)')
+       gcloud projects add-iam-policy-binding %s \
+         --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+         --role="roles/cloudbuild.builds.builder"
+       # Build and push:
        gcloud builds submit --tag %s --project=%s .
 
   5. Re-run:
@@ -171,7 +177,7 @@ func imageInstructions(name, project, region string) string {
 		repo, name,
 		name, name, name, name,
 		region, image, image,
-		project, image, project,
+		project, project, project, image, project,
 		name,
 	)
 }


### PR DESCRIPTION
## Summary

- Adds the required IAM setup steps to the **Option B — Cloud Build** block in the README and the `snipemgr run` inline instructions
- Without the `roles/cloudbuild.builds.builder` grant on the Cloud Build service account, `gcloud builds submit` fails with a 403 reading the source tarball from Cloud Storage (confirmed in production)
- Both places now include: enable API → look up project number → grant IAM role → build and push, with a note explaining why the grant is needed

## Test plan

- [ ] `snipemgr run <name>` when no image exists: verify Option B block shows IAM grant commands with correct project substitution
- [ ] README Option B block renders correctly on GitHub