### PR TITLE
docs: add artifactregistry.writer and logging.logWriter IAM grants to Cloud Build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,8 +236,14 @@ docker push us-central1-docker.pkg.dev/YOUR_PROJECT_ID/snipe-integrations/github
 gcloud services enable cloudbuild.googleapis.com --project=YOUR_PROJECT_ID
 PROJECT_NUMBER=$(gcloud projects describe YOUR_PROJECT_ID --format='value(projectNumber)')
 gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
-  --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
   --role="roles/cloudbuild.builds.builder"
+gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role="roles/artifactregistry.writer"
+gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role="roles/logging.logWriter"
 
 # Build and push:
 gcloud builds submit \
@@ -245,7 +251,7 @@ gcloud builds submit \
   --project=YOUR_PROJECT_ID .
 ```
 
-> The IAM grant is required once per project. Without it Cloud Build fails with a 403 reading the source upload from Cloud Storage.
+> These three IAM grants are required once per project. `cloudbuild.builds.builder` allows Cloud Build to read its source upload from Cloud Storage; `artifactregistry.writer` allows it to push the built image; `logging.logWriter` allows build logs to appear in Cloud Logging.
 
 Replace `YOUR_PROJECT_ID` and `github2snipe` with your project and integration name. The image path pattern is:
 ```

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -164,8 +164,14 @@ func imageInstructions(name, project, region string) string {
        gcloud services enable cloudbuild.googleapis.com --project=%s
        PROJECT_NUMBER=$(gcloud projects describe %s --format='value(projectNumber)')
        gcloud projects add-iam-policy-binding %s \
-         --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
+         --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
          --role="roles/cloudbuild.builds.builder"
+       gcloud projects add-iam-policy-binding %s \
+         --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+         --role="roles/artifactregistry.writer"
+       gcloud projects add-iam-policy-binding %s \
+         --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+         --role="roles/logging.logWriter"
        # Build and push:
        gcloud builds submit --tag %s --project=%s .
 
@@ -177,7 +183,7 @@ func imageInstructions(name, project, region string) string {
 		repo, name,
 		name, name, name, name,
 		region, image, image,
-		project, project, project, image, project,
+		project, project, project, project, project, image, project,
 		name,
 	)
 }


### PR DESCRIPTION
## Summary

Follows up on #28. The previous Cloud Build setup instructions were missing two IAM grants that are required for a successful build:

- `roles/artifactregistry.writer` — without this the push step fails with `Permission 'artifactregistry.repositories.uploadArtifacts' denied` (confirmed in production)
- `roles/logging.logWriter` — without this Cloud Build cannot write logs to Cloud Logging (surfaces as an INFO warning in build output)

Also corrects the service account principal from `PROJECT_NUMBER@cloudbuild.gserviceaccount.com` to `PROJECT_NUMBER-compute@developer.gserviceaccount.com`, which is the Compute Engine default SA that Cloud Build actually uses.

All five integration repo READMEs updated in parallel.