### PR TITLE
feat(cmd): add shell completion and integration-name dynamic completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ snipemgr run <name>               Trigger a Cloud Run Job immediately
 snipemgr enable <name>            Resume a paused Cloud Scheduler job
 snipemgr disable <name>           Pause scheduling without removing the integration
 snipemgr upgrade                  Check for and apply newer versions of installed integrations
+snipemgr completion [shell]       Generate shell completion scripts
 ```
 
 Global flags on all commands: `--config`, `-v/--verbose`, `-d/--debug`, `--log-file`, `--log-format`, `--no-interactive`
@@ -256,6 +257,34 @@ gcloud builds submit \
 Replace `YOUR_PROJECT_ID` and `github2snipe` with your project and integration name. The image path pattern is:
 ```
 {region}-docker.pkg.dev/{project}/snipe-integrations/{integration-name}:latest
+```
+
+## Shell completion
+
+Generate and install shell completions with the built-in `completion` command.
+
+**Bash**
+
+```bash
+# Linux
+snipemgr completion bash > /etc/bash_completion.d/snipemgr
+
+# macOS
+snipemgr completion bash > "$(brew --prefix)/etc/bash_completion.d/snipemgr"
+```
+
+**Zsh**
+
+```bash
+mkdir -p "${fpath[1]}"
+snipemgr completion zsh > "${fpath[1]}/_snipemgr"
+```
+
+**Fish**
+
+```bash
+mkdir -p ~/.config/fish/completions
+snipemgr completion fish > ~/.config/fish/completions/snipemgr.fish
 ```
 
 After pushing, trigger the job:

--- a/README.md
+++ b/README.md
@@ -144,6 +144,42 @@ Pass `--no-interactive` without `--all` to list available upgrades without apply
 
 ---
 
+## Shell completion
+
+Generate and install shell completions with the built-in `completion` command.
+
+**Bash**
+
+```bash
+# Linux
+snipemgr completion bash > /etc/bash_completion.d/snipemgr
+
+# macOS
+snipemgr completion bash > "$(brew --prefix)/etc/bash_completion.d/snipemgr"
+```
+
+**Zsh**
+
+```bash
+mkdir -p "${fpath[1]}"
+snipemgr completion zsh > "${fpath[1]}/_snipemgr"
+```
+
+**Fish**
+
+```bash
+mkdir -p ~/.config/fish/completions
+snipemgr completion fish > ~/.config/fish/completions/snipemgr.fish
+```
+
+**PowerShell**
+
+```powershell
+snipemgr completion powershell | Out-String | Invoke-Expression
+```
+
+---
+
 ## GCP setup (required for `--secrets-backend gcp`)
 
 GCP Secret Manager, Cloud Run Jobs, and Cloud Scheduler are used when you install an integration with `--secrets-backend gcp`. Complete this one-time setup before your first GCP-backend install:
@@ -257,34 +293,6 @@ gcloud builds submit \
 Replace `YOUR_PROJECT_ID` and `github2snipe` with your project and integration name. The image path pattern is:
 ```
 {region}-docker.pkg.dev/{project}/snipe-integrations/{integration-name}:latest
-```
-
-## Shell completion
-
-Generate and install shell completions with the built-in `completion` command.
-
-**Bash**
-
-```bash
-# Linux
-snipemgr completion bash > /etc/bash_completion.d/snipemgr
-
-# macOS
-snipemgr completion bash > "$(brew --prefix)/etc/bash_completion.d/snipemgr"
-```
-
-**Zsh**
-
-```bash
-mkdir -p "${fpath[1]}"
-snipemgr completion zsh > "${fpath[1]}/_snipemgr"
-```
-
-**Fish**
-
-```bash
-mkdir -p ~/.config/fish/completions
-snipemgr completion fish > ~/.config/fish/completions/snipemgr.fish
 ```
 
 After pushing, trigger the job:

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/jackvaughanjr/2snipe-manager/internal/state"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var completionCmd = &cobra.Command{
+	Use:                   "completion [bash|zsh|fish|powershell]",
+	Short:                 "Generate shell completion scripts",
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	DisableFlagsInUseLine: true,
+	Long: `Generate shell completion scripts for snipemgr.
+
+To load completions:
+
+Bash:
+
+  Linux:
+    snipemgr completion bash > /etc/bash_completion.d/snipemgr
+
+  macOS:
+    snipemgr completion bash > "$(brew --prefix)/etc/bash_completion.d/snipemgr"
+
+Zsh:
+  mkdir -p "${fpath[1]}"
+  snipemgr completion zsh > "${fpath[1]}/_snipemgr"
+
+Fish:
+  mkdir -p ~/.config/fish/completions
+  snipemgr completion fish > ~/.config/fish/completions/snipemgr.fish
+
+PowerShell:
+  snipemgr completion powershell | Out-String | Invoke-Expression
+
+To configure your shell to load completions for each session, see your shell's
+documentation for completion support.`,
+	RunE: runCompletion,
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}
+
+func runCompletion(cmd *cobra.Command, args []string) error {
+	switch args[0] {
+	case "bash":
+		return cmd.Root().GenBashCompletion(os.Stdout)
+	case "zsh":
+		return cmd.Root().GenZshCompletion(os.Stdout)
+	case "fish":
+		return cmd.Root().GenFishCompletion(os.Stdout, true)
+	case "powershell":
+		return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+	default:
+		return fmt.Errorf("unsupported shell %q", args[0])
+	}
+}
+
+func integrationNameCompletion(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	statePath := viper.GetString("state.path")
+	if statePath == "" {
+		statePath = "~/.snipemgr/state.json"
+	}
+
+	s, err := state.ReadState(statePath)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	names := slices.Sorted(maps.Keys(s.Integrations))
+	if toComplete == "" {
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	matches := make([]string, 0, len(names))
+	for _, name := range names {
+		if strings.HasPrefix(name, toComplete) {
+			matches = append(matches, name)
+		}
+	}
+
+	return matches, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/disable.go
+++ b/cmd/disable.go
@@ -11,8 +11,9 @@ import (
 )
 
 var disableCmd = &cobra.Command{
-	Use:   "disable <name>",
-	Short: "Pause an integration's scheduled runs",
+	Use:               "disable <name>",
+	Short:             "Pause an integration's scheduled runs",
+	ValidArgsFunction: integrationNameCompletion,
 	Long: `Pause the Cloud Scheduler trigger for an integration without removing it.
 The integration can be resumed with 'snipemgr enable'. Has no effect on
 local-backend integrations.`,

--- a/cmd/enable.go
+++ b/cmd/enable.go
@@ -11,8 +11,9 @@ import (
 )
 
 var enableCmd = &cobra.Command{
-	Use:   "enable <name>",
-	Short: "Resume a paused integration schedule",
+	Use:               "enable <name>",
+	Short:             "Resume a paused integration schedule",
+	ValidArgsFunction: integrationNameCompletion,
 	Long: `Resume the Cloud Scheduler trigger for an integration that was previously
 disabled with 'snipemgr disable'. Has no effect on local-backend integrations.`,
 	Args: cobra.ExactArgs(1),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,8 +14,9 @@ import (
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run <name>",
-	Short: "Trigger an integration's Cloud Run Job immediately",
+	Use:               "run <name>",
+	Short:             "Trigger an integration's Cloud Run Job immediately",
+	ValidArgsFunction: integrationNameCompletion,
 	Long: `Trigger the Cloud Run Job for an installed integration outside of its
 scheduled time. The job runs asynchronously — check results with 'snipemgr status'.`,
 	Args: cobra.ExactArgs(1),

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -14,10 +14,11 @@ import (
 )
 
 var uninstallCmd = &cobra.Command{
-	Use:   "uninstall <name>",
-	Short: "Remove an installed integration (binary, config, GCP resources, and state entry)",
-	Args:  cobra.ExactArgs(1),
-	RunE:  silentUsage(runUninstall),
+	Use:               "uninstall <name>",
+	Short:             "Remove an installed integration (binary, config, GCP resources, and state entry)",
+	ValidArgsFunction: integrationNameCompletion,
+	Args:              cobra.ExactArgs(1),
+	RunE:              silentUsage(runUninstall),
 }
 
 func init() {


### PR DESCRIPTION
## What does this PR do?

Closes #21. Wires up cobra's built-in completion generator as `snipemgr completion [bash|zsh|fish|powershell]`, and attaches a shared `ValidArgsFunction` to the four commands that take an installed integration name (`run`, `disable`, `enable`, `uninstall`) so tab completion surfaces real installed names from the state file. README gets a "Shell completion" section with the copy-pasteable install commands.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [ ] Other:

## Testing

- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./...` - all packages pass (`cmd`, `internal/installer`, `internal/registry`, `internal/scheduler`, `internal/secrets`, `internal/snipeit`, `internal/state`, `internal/wizard`).
- Manual spot-checks:
  - `go run . completion bash | head -1` → `# bash completion for snipemgr ...`
  - `go run . completion zsh | head -3` → contains `#compdef snipemgr`
  - `go run . completion fish | head -1` → `# fish completion for snipemgr ...`
  - `go run . completion powershell` produces a `Register-ArgumentCompleter` script.

## Checklist

- [x] `go vet ./...` passes
- [x] Tests pass (`go test ./...`)
- [x] `snipemgr.example.yaml` updated if new config fields were added - N/A, no new config fields.
- [x] README updated if user-visible behaviour changed - added Shell completion section.

## Design notes

`upgrade` is intentionally left unchanged because its current `Use` line takes no positional integration-name argument. Adding `ValidArgsFunction` there would imply a new positional argument the command doesn't accept today. Happy to follow up if you want to broaden `upgrade` to accept a list of names in a separate PR.

`integrationNameCompletion` lives in `cmd/completion.go` alongside the subcommand rather than in a shared helpers file, since all five commands that use it are already in `cmd/`. It re-uses the same `viper.GetString("state.path")` resolution as the `RunE` functions so completion and execution always read the same state.

_This contribution was developed with AI assistance (Codex)._
