### PR TITLE
ci: pin GitHub Actions to specific versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5.5.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
   build-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5.5.0
         with:
           go-version-file: go.mod
 
@@ -85,7 +85,7 @@ jobs:
           rm -f api_key.p8
           security delete-keychain build.keychain
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6.2
         with:
           name: macos-binaries
           path: dist/
@@ -93,12 +93,12 @@ jobs:
   build-other:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v5.5.0
         with:
           go-version-file: go.mod
 
@@ -111,7 +111,7 @@ jobs:
           GOOS=linux   GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-linux-arm64"       .
           GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o "dist/snipemgr-windows-amd64.exe" .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.6.2
         with:
           name: other-binaries
           path: dist/
@@ -120,17 +120,17 @@ jobs:
     needs: [build-macos, build-other]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4.3.0
         with:
           name: macos-binaries
           path: dist/
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4.3.0
         with:
           name: other-binaries
           path: dist/


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` to `v4.2.2`
- Pin `actions/setup-go` to `v5.5.0`
- Pin `actions/upload-artifact` to `v4.6.2`
- Pin `actions/download-artifact` to `v4.3.0`

## Test plan
- [ ] CI passes on this branch