### PR TITLE
feat: write snipemgr.yaml to ~/.snipemgr/ by default; add `where` command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/huh"
@@ -30,8 +31,11 @@ func init() {
 		"overwrite existing snipemgr.yaml without prompting for confirmation")
 }
 
-func runInit(_ *cobra.Command, _ []string) error {
-	configPath := cfgFile // honours --config flag; defaults to "snipemgr.yaml"
+func runInit(cmd *cobra.Command, _ []string) error {
+	configPath := cfgFile
+	if !cmd.Root().PersistentFlags().Changed("config") {
+		configPath = resolveConfigPath()
+	}
 
 	// Check for an existing config file and require confirmation before overwriting.
 	if _, err := os.Stat(configPath); err == nil {
@@ -197,12 +201,17 @@ func runInit(_ *cobra.Command, _ []string) error {
 	}
 
 	// Write snipemgr.yaml (0600: may contain credentials).
+	if dir := filepath.Dir(configPath); dir != "." {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return fatal("creating config directory %s: %v", dir, err)
+		}
+	}
 	content := buildInitConfig(extraOwner, githubToken, snipeURL, snipeToken, gcpProject, gcpRegion, gcpSA, gcpTimezone)
 	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
 		return fatal("writing %s: %v", configPath, err)
 	}
 
-	fmt.Printf("✓ %s written\n", configPath)
+	fmt.Printf("✓ snipemgr.yaml written to %s\n", configPath)
 	fmt.Println("  Run 'snipemgr list' to see available integrations.")
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ into Snipe-IT — from a single place.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		cmd.Root().SilenceErrors = true // suppress cobra's duplicate "Error: ..." echo
 		initLogging()
-		if configFileMissing && cmd.Name() != "init" {
+		if configFileMissing && cmd.Name() != "init" && cmd.Name() != "where" {
 			fmt.Fprintf(os.Stderr, "Note: %s not found — run 'snipemgr init' to create it\n\n", cfgFile)
 		}
 		return nil
@@ -168,4 +168,14 @@ func expandHome(path string) (string, error) {
 		return filepath.Join(home, path[2:]), nil
 	}
 	return path, nil
+}
+
+// resolveConfigPath returns the canonical path for snipemgr.yaml when --config
+// is not explicitly set: ~/.snipemgr/snipemgr.yaml, falling back to cwd.
+func resolveConfigPath() string {
+	const filename = "snipemgr.yaml"
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".snipemgr", filename)
+	}
+	return filename
 }

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var whereCmd = &cobra.Command{
+	Use:   "where",
+	Short: "Print the paths snipemgr is using for config, state, and binaries",
+	Long: `Print the resolved paths for snipemgr's config file, state file, and binary
+directory. Reports "(not found)" for files that do not exist. Always exits 0.`,
+	RunE: silentUsage(runWhere),
+}
+
+func init() {
+	rootCmd.AddCommand(whereCmd)
+}
+
+func runWhere(cmd *cobra.Command, _ []string) error {
+	exePath := "(unknown)"
+	if exe, err := os.Executable(); err == nil {
+		exePath = exe
+	}
+
+	configPath := cfgFile
+	if !cmd.Root().PersistentFlags().Changed("config") {
+		configPath = resolveConfigPath()
+	}
+
+	statePath := viper.GetString("state.path")
+	if statePath == "" {
+		home, _ := os.UserHomeDir()
+		statePath = filepath.Join(home, ".snipemgr", "state.json")
+	} else if expanded, err := expandHome(statePath); err == nil {
+		statePath = expanded
+	}
+
+	binDir := viper.GetString("install.bin_dir")
+	if binDir == "" {
+		home, _ := os.UserHomeDir()
+		binDir = filepath.Join(home, ".snipemgr", "bin")
+	} else if expanded, err := expandHome(binDir); err == nil {
+		binDir = expanded
+	}
+
+	fmt.Printf("Binary:   %s\n", exePath)
+	fmt.Printf("Config:   %s\n", pathDisplay(configPath))
+	fmt.Printf("State:    %s\n", pathDisplay(statePath))
+	fmt.Printf("Bin dir:  %s\n", pathDisplay(binDir))
+	return nil
+}
+
+// pathDisplay appends "(not found)" when the path does not exist on disk.
+func pathDisplay(path string) string {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return path + "  (not found)"
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

- `snipemgr init` now writes `snipemgr.yaml` to `~/.snipemgr/snipemgr.yaml` instead of the current working directory, so config, state, and managed binaries all live under one predictable location
- Creates `~/.snipemgr/` if it doesn't exist yet
- `--config` flag continues to override the resolved path
- Adds `snipemgr where` diagnostic command that prints Binary, Config, State, and Bin dir paths — reports `(not found)` for missing files, always exits 0

## Test plan

- [ ] `snipemgr where` with no config — shows `~/.snipemgr/snipemgr.yaml  (not found)` for Config
- [ ] `snipemgr where --config /tmp/foo.yaml` — Config line reflects the override
- [ ] `snipemgr init` (no `--config`) — writes to `~/.snipemgr/snipemgr.yaml`, prints full path in success message
- [ ] `snipemgr init --config ./custom.yaml` — writes to `./custom.yaml` (existing behaviour unchanged)
- [ ] `snipemgr init` when `~/.snipemgr/` does not exist — directory is created automatically
- [ ] `snipemgr where` with a valid config — State and Bin dir reflect values from the config file

Closes #30