### PR TITLE
fix: pre-fill Snipe-IT credentials from snipemgr.yaml in install/config wizard

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -83,7 +83,15 @@ func runConfig(_ *cobra.Command, args []string) error {
 			return fatal("%v", err)
 		}
 	} else {
-		result, err := wizard.RunInteractive(target.Manifest, nil)
+		existing := viperSnipeDefaults()
+		if fm, err := buildFieldMap(); err == nil {
+			for k, v := range fm {
+				if v != "" {
+					existing[k] = v
+				}
+			}
+		}
+		result, err := wizard.RunInteractive(target.Manifest, existing)
 		if err != nil {
 			return fatal("wizard: %v", err)
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -149,8 +149,9 @@ func runInstall(_ *cobra.Command, args []string) error {
 			return fatal("%v", err)
 		}
 	} else {
-		// Populate wizard with any pre-supplied flag values.
-		existing := make(map[string]string)
+		// Seed wizard with Snipe-IT credentials from snipemgr.yaml, then overlay
+		// any explicit flags so flags always win.
+		existing := viperSnipeDefaults()
 		if fm, err := buildFieldMap(); err == nil {
 			for k, v := range fm {
 				if v != "" {
@@ -397,6 +398,20 @@ func keyLastSegment(key, prefix string) string {
 		seg = key[len(prefix)+1:]
 	}
 	return strings.ReplaceAll(seg, "_", "-")
+}
+
+// viperSnipeDefaults returns a map pre-seeded with any snipe_it.* values already
+// present in snipemgr.yaml so the wizard does not re-prompt for credentials the
+// user set during init.
+func viperSnipeDefaults() map[string]string {
+	m := make(map[string]string)
+	if u := viper.GetString("snipe_it.url"); u != "" {
+		m["snipe_it.url"] = u
+	}
+	if t := viper.GetString("snipe_it.api_key"); t != "" {
+		m["snipe_it.api_key"] = t
+	}
+	return m
 }
 
 // buildFieldMap constructs the key→value map from --snipe-url, --snipe-token,


### PR DESCRIPTION
## Summary

- `snipemgr install` and `snipemgr config` wizards now seed `snipe_it.url` and `snipe_it.api_key` from `snipemgr.yaml` (via viper) before the wizard runs — users who set credentials during `init` are no longer re-prompted
- CLI flags `--snipe-url` / `--snipe-token` still override the pre-filled values (flags are merged in after the viper seed)
- Extracted `viperSnipeDefaults()` helper shared by both commands

## Test plan

- [ ] Run `snipemgr install <name>` after setting `snipe_it.url` and `snipe_it.api_key` in `snipemgr.yaml` — wizard should skip those fields (or show them pre-filled)
- [ ] Run with `--snipe-url` / `--snipe-token` flags — flag values should override the config file values
- [ ] Run `snipemgr config <name>` — same pre-fill behaviour
- [ ] `--no-interactive` mode is unchanged

Closes #32